### PR TITLE
Revoke a OAuth 2 Bearer Token

### DIFF
--- a/src/Thujohn/Twitter/Twitter.php
+++ b/src/Thujohn/Twitter/Twitter.php
@@ -442,4 +442,16 @@ class Twitter extends tmhOAuth {
 		}
 	}
 
+	/**
+	 * Allows a registered application to revoke an issued OAuth 2 Bearer Token by presenting its client credentials.
+	 * Once a Bearer Token has been invalidated, new creation attempts will yield a different Bearer Token and usage of the invalidated token will no longer be allowed.
+	 */
+	public function revokeToken()
+	{
+		if(isset($access_token['oauth_token']))
+		{
+			return $this->post('oauth2/invalidate_token', $access_token['oauth_token']);
+		}
+	}
+
 }


### PR DESCRIPTION
Is there any need for a revoke mechanism because I couldn't find a way to revoke my user access or did I just overlook something? I know you can't revoke the application trough the API.

Allows a registered application to revoke an issued OAuth 2 Bearer Token by presenting its client credentials.
Once a Bearer Token has been invalidated, new creation attempts will yield a different Bearer Token and usage of the invalidated token will no longer be allowed.

https://dev.twitter.com/oauth/reference/post/oauth2/invalidate/token
