### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,10 +189,12 @@ Route::get('twitter/callback', ['as' => 'twitter.callback', function() {
 		if (Input::has('oauth_verifier'))
 		{
 			$oauth_verifier = Input::get('oauth_verifier');
+			// getAccessToken() will reset the token for you
+			$token = Twitter::getAccessToken($oauth_verifier);
 		}
 
-		// getAccessToken() will reset the token for you
-		$token = Twitter::getAccessToken($oauth_verifier);
+		
+		
 
 		if (!isset($token['oauth_token_secret']))
 		{


### PR DESCRIPTION
Incase the user did not autorise your YourAppName, going "back to YouAppName" button will trow an exception because the callback function will try to get an access token with a parameter of false...
