### PR TITLE
Change getUsersLookup to use post method

### DIFF
--- a/src/Thujohn/Twitter/Traits/UserTrait.php
+++ b/src/Thujohn/Twitter/Traits/UserTrait.php
@@ -12,14 +12,14 @@ Trait UserTrait {
 	 * - screen_name
 	 * - include_entities (0|1)
 	 */
-	public function getUsersLookup($parameters = [])
+	public function postUsersLookup($parameters = [])
 	{
 		if (!array_key_exists('user_id', $parameters) && !array_key_exists('screen_name', $parameters))
 		{
 			throw new Exception("Parameter required missing : user_id or screen_name");
 		}
 
-		return $this->get('users/lookup', $parameters);
+		return $this->post('users/lookup', $parameters);
 	}
 
 	/**

--- a/tests/Thujohn/Twitter/TwitterTest.php
+++ b/tests/Thujohn/Twitter/TwitterTest.php
@@ -65,24 +65,24 @@ class TwitterTest extends \PHPUnit_Framework_TestCase
         ));
     }
 
-    public function testGetUsersLookupWithIds()
+    public function testPostUsersLookupWithIds()
     {
         $twitter = $this->getTwitterExpecting('users/lookup', array(
             'user_id' => '1,2,3,4'
         ));
 
-        $twitter->getUsersLookup(array(
+        $twitter->postUsersLookup(array(
             'user_id' => implode(',', array(1, 2, 3, 4))
         ));
     }
 
-    public function testGetUsersLookupWithScreenNames()
+    public function testPostUsersLookupWithScreenNames()
     {
         $twitter = $this->getTwitterExpecting('users/lookup', array(
             'screen_name' => 'me,you,everybody'
         ));
 
-        $twitter->getUsersLookup(array(
+        $twitter->postUsersLookup(array(
             'screen_name' => implode(',', array('me', 'you', 'everybody'))
         ));
     }
@@ -90,11 +90,11 @@ class TwitterTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException Exception
      */
-    public function testGetUsersLookupInvalid()
+    public function testPostUsersLookupInvalid()
     {
         $twitter = $this->getTwitter();
 
-        $twitter->getUsersLookup(array(
+        $twitter->postUsersLookup(array(
             'include_entities' => true
         ));
     }


### PR DESCRIPTION
It's recommended that you always use a post request for fetching info for multiple users. Most of the time it's gonna exhaust the get parameters recommended size and you are gonna get an error. In short, better use post method with such large parameters as requested.
