### PR TITLE
Made it possible to specify API host on get(), post(), query(). Fix postProfileImage() to use API_URL.

### DIFF
--- a/src/Thujohn/Twitter/Traits/AccountTrait.php
+++ b/src/Thujohn/Twitter/Traits/AccountTrait.php
@@ -118,7 +118,7 @@ Trait AccountTrait {
 			throw new Exception('Parameter required missing : image');
 		}
 
-		return $this->post('account/update_profile_image', $parameters, true);
+		return $this->post('account/update_profile_image', $parameters, true, $this->tconfig['API_URL']);
 	}
 
 	/**

--- a/src/Thujohn/Twitter/Twitter.php
+++ b/src/Thujohn/Twitter/Twitter.php
@@ -224,13 +224,17 @@ class Twitter extends tmhOAuth {
 		}
 	}
 
-	public function query($name, $requestMethod = 'GET', $parameters = [], $multipart = false)
+	public function query($name, $requestMethod = 'GET', $parameters = [], $multipart = false, $host = '')
 	{
-		$this->config['host'] = $this->tconfig['API_URL'];
+		if ($host) {
+			$this->config['host'] = $host;
+		} else {
+			$this->config['host'] = $this->tconfig['API_URL'];
 
-		if ($multipart)
-		{
-			$this->config['host'] = $this->tconfig['UPLOAD_URL'];
+			if ($multipart)
+			{
+				$this->config['host'] = $this->tconfig['UPLOAD_URL'];
+			}
 		}
 
 		$url = parent::url($this->tconfig['API_VERSION'].'/'.$name);
@@ -311,14 +315,14 @@ class Twitter extends tmhOAuth {
 		return $response;
 	}
 
-	public function get($name, $parameters = [], $multipart = false)
+	public function get($name, $parameters = [], $multipart = false, $host = '')
 	{
-		return $this->query($name, 'GET', $parameters, $multipart);
+		return $this->query($name, 'GET', $parameters, $multipart, $host);
 	}
 
-	public function post($name, $parameters = [], $multipart = false)
+	public function post($name, $parameters = [], $multipart = false, $host = '')
 	{
-		return $this->query($name, 'POST', $parameters, $multipart);
+		return $this->query($name, 'POST', $parameters, $multipart, $host);
 	}
 
 	public function linkify($tweet)


### PR DESCRIPTION
According to current Twitter Public API Document, `POST account/update_profile_image` must be send to API_URL ( `https://api.twitter.com/1.1/account/update_profile_image.json` ).

https://dev.twitter.com/rest/reference/post/account/update_profile_image

However, current implementation of postProfileImage() send request to UPLOAD_URL and it cause error. I made it possible to specify API host on get(), post(), query() with adding extra argument, then added API_URL argument to  postProfileImage().
