### PR TITLE
ZWNJ and Underscore are valid hashtag characters

### DIFF
--- a/src/Thujohn/Twitter/Twitter.php
+++ b/src/Thujohn/Twitter/Twitter.php
@@ -342,7 +342,7 @@ class Twitter extends tmhOAuth {
 		$patterns['url']      = '(?xi)\b((?:https?://|www\d{0,3}[.]|[a-z0-9.\-]+[.][a-z]{2,4}/)(?:[^\s()<>]+|\(([^\s()<>]+|(\([^\s()<>]+\)))*\))+(?:\(([^\s()<>]+|(\([^\s()<>]+\)))*\)|[^\s`!()\[\]{};:\'".,<>?«»“”‘’]))';
 		$patterns['mailto']   = '([_a-z0-9-]+(\.[_a-z0-9-]+)*@[a-z0-9-]+(\.[a-z0-9-]+)*(\.[a-z]{2,3}))';
 		$patterns['user']     = ' +@([a-z0-9_]*)?';
-		$patterns['hashtag']  = '(?:(?<=\s)|^)#(\w*[\p{L}-\d\p{Cyrillic}\d]+\w*)';
+		$patterns['hashtag']  = '(?:(?<=\s)|^)#(\w*[\p{L}-\d\x{200c}_\p{Cyrillic}\d]+\w*)';
 		$patterns['long_url'] = '>(([[:alnum:]]+:\/\/)|www\.)?([^[:space:]]{12,22})([^[:space:]]*)([^[:space:]]{12,22})([[:alnum:]#?\/&=])<';
 
 		if ($type == 'text')


### PR DESCRIPTION
I'm not sure if there is anything else beside these two
