### PR TITLE
Update Direct Message Trait

### DIFF
--- a/src/Thujohn/Twitter/Traits/DirectMessageTrait.php
+++ b/src/Thujohn/Twitter/Traits/DirectMessageTrait.php
@@ -49,6 +49,17 @@ Trait DirectMessageTrait {
 	{
 		return $this->get('direct_messages', $parameters);
 	}
+	
+	/**
+	* Returns all Direct Message events (both sent and received) within the last 30 days. Sorted in reverse-chronological order.
+	* Parameters :
+	* - count(optional) - Max number of events to be returned. 20 default. 50 max.
+	* - cursor(optional) - For paging through result sets greater than 1 page, use the “next_cursor” property from the previous request.
+	*/
+	public function getDmAll($parameters = [])
+	{
+		return $this->get('direct_messages/events/list', $parameters); 
+	}
 
 	/**
 	 * Destroys the direct message specified in the required ID parameter. The authenticating user must be the recipient of the specified direct message.


### PR DESCRIPTION
Added getDmAll method, for retrieving all Direct Message events (both sent and received) within the last 30 days. Sorted in reverse-chronological order, using Twitter Api's new endpoint