### PR TITLE
fix: autoload facade

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,10 @@
         "laravel": {
             "providers": [
                 "Thujohn\\Twitter\\TwitterServiceProvider"
-            ]
+            ],
+            "aliases": {
+                "Twitter": "Thujohn\\Twitter\\Facades\\Twitter"
+            }
         }
     },
     "minimum-stability": "stable"


### PR DESCRIPTION
The facade should be auto discovered along side the service provider. 

Closes #276 