### PR TITLE
Allow specifying request format separately from response format

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ Returns a collection of the most recent Tweets posted by the user indicated by t
 ```php
 Route::get('/userTimeline', function()
 {
-	return Twitter::getUserTimeline(['screen_name' => 'thujohn', 'count' => 20, 'format' => 'json']);
+	return Twitter::getUserTimeline(['screen_name' => 'thujohn', 'count' => 20, 'response_format' => 'json']);
 });
 ```
 
@@ -241,7 +241,7 @@ Returns a collection of the most recent Tweets and retweets posted by the authen
 ```php
 Route::get('/homeTimeline', function()
 {
-	return Twitter::getHomeTimeline(['count' => 20, 'format' => 'json']);
+	return Twitter::getHomeTimeline(['count' => 20, 'response_format' => 'json']);
 });
 ```
 
@@ -249,7 +249,7 @@ Returns the X most recent mentions (tweets containing a users's @screen_name) fo
 ```php
 Route::get('/mentionsTimeline', function()
 {
-	return Twitter::getMentionsTimeline(['count' => 20, 'format' => 'json']);
+	return Twitter::getMentionsTimeline(['count' => 20, 'response_format' => 'json']);
 });
 ```
 
@@ -257,7 +257,7 @@ Updates the authenticating user's current status, also known as tweeting.
 ```php
 Route::get('/tweet', function()
 {
-	return Twitter::postTweet(['status' => 'Laravel is beautiful', 'format' => 'json']);
+	return Twitter::postTweet(['status' => 'Laravel is beautiful', 'response_format' => 'json']);
 });
 ```
 
@@ -356,7 +356,7 @@ Then you can access the logs() method.
 ```php
 try
 {
-	$response = Twitter::getUserTimeline(['count' => 20, 'format' => 'array']);
+	$response = Twitter::getUserTimeline(['count' => 20, 'response_format' => 'array']);
 }
 catch (Exception $e)
 {

--- a/src/Traits/AuthTrait.php
+++ b/src/Traits/AuthTrait.php
@@ -26,7 +26,7 @@ trait AuthTrait
             self::REQUEST_METHOD_GET,
             [
                 Twitter::KEY_OAUTH_CALLBACK => $callbackUrl,
-                Twitter::KEY_FORMAT => self::RESPONSE_FORMAT_JSON,
+                Twitter::KEY_RESPONSE_FORMAT => self::RESPONSE_FORMAT_JSON,
             ]
         );
 
@@ -64,7 +64,7 @@ trait AuthTrait
             self::REQUEST_METHOD_GET,
             [
                 Twitter::KEY_OAUTH_VERIFIER => $oauthVerifier,
-                Twitter::KEY_FORMAT => self::RESPONSE_FORMAT_JSON,
+                Twitter::KEY_RESPONSE_FORMAT => self::RESPONSE_FORMAT_JSON,
             ]
         );
 

--- a/src/Traits/DirectMessageTrait.php
+++ b/src/Traits/DirectMessageTrait.php
@@ -2,6 +2,7 @@
 
 namespace Atymic\Twitter\Traits;
 
+use Atymic\Twitter\Twitter;
 use BadMethodCallException;
 
 trait DirectMessageTrait
@@ -78,6 +79,8 @@ trait DirectMessageTrait
                 sprintf('Missing required parameter: `event`. See %s', $apiReference)
             );
         }
+
+        $parameters[Twitter::KEY_REQUEST_FORMAT] = Twitter::REQUEST_FORMAT_JSON;
 
         return $this->post('direct_messages/events/new', $parameters);
     }

--- a/src/Traits/DirectMessageTrait.php
+++ b/src/Traits/DirectMessageTrait.php
@@ -55,7 +55,9 @@ trait DirectMessageTrait
     }
 
     /**
-     * Publishes a new message_create event resulting in a Direct Message sent to a specified user from the authenticating user. Returns an event if successful. Supports publishing Direct Messages with optional Quick Reply and media attachment.
+     * Publishes a new message_create event resulting in a Direct Message sent to a specified user from the
+     * authenticating user. Returns an event if successful. Supports publishing Direct Messages with optional Quick
+     * Reply and media attachment.
      *
      * Parameters :
      * - type
@@ -64,11 +66,17 @@ trait DirectMessageTrait
      * @see https://developer.twitter.com/en/docs/direct-messages/sending-and-receiving/api-reference/new-event
      *
      * @param mixed $parameters
+     *
+     * @throws BadMethodCallException
      */
     public function postDm($parameters = [])
     {
-        if ((!array_key_exists('type', $parameters) && !array_key_exists('message_create', $parameters))) {
-            throw new BadMethodCallException('Parameter required missing : user_id, screen_name or text');
+        $apiReference = 'https://developer.twitter.com/en/docs/direct-messages/sending-and-receiving/api-reference/new-event';
+
+        if (!array_key_exists('event', $parameters)) {
+            throw new BadMethodCallException(
+                sprintf('Missing required parameter: `event`. See %s', $apiReference)
+            );
         }
 
         return $this->post('direct_messages/events/new', $parameters);

--- a/src/Twitter.php
+++ b/src/Twitter.php
@@ -58,11 +58,15 @@ class Twitter
     public const VERSION = '3.x-dev';
 
     public const KEY_REQUEST_FORMAT = 'request_format';
-    public const KEY_RESPONSE_FORMAT = 'format';
+    public const KEY_RESPONSE_FORMAT = 'response_format';
+    public const KEY_FORMAT = 'format';
     public const KEY_OAUTH_CALLBACK = 'oauth_callback';
     public const KEY_OAUTH_VERIFIER = 'oauth_verifier';
     public const KEY_OAUTH_TOKEN = 'oauth_token';
     public const KEY_OAUTH_TOKEN_SECRET = 'oauth_token_secret';
+
+    public const REQUEST_FORMAT_JSON = RequestOptions::JSON;
+    public const REQUEST_FORMAT_MULTIPART = RequestOptions::MULTIPART;
 
     public const RESPONSE_FORMAT_ARRAY = 'array';
     public const RESPONSE_FORMAT_OBJECT = 'object';
@@ -243,19 +247,19 @@ class Twitter
     }
 
     /**
-     * @param array  $params
-     * @param string $requestMethod
-     * @param string $requestFormat
+     * @param array       $params
+     * @param string      $requestMethod
+     * @param string|null $requestFormat
      *
      * @return array
      */
-    private function getRequestOptions(array $params, string $requestMethod, string $requestFormat): array
+    private function getRequestOptions(array $params, string $requestMethod, ?string $requestFormat): array
     {
         switch ($requestFormat) {
-            case RequestOptions::JSON:
+            case self::REQUEST_FORMAT_JSON:
                 $paramsKey = RequestOptions::JSON;
                 break;
-            case RequestOptions::MULTIPART:
+            case self::REQUEST_FORMAT_MULTIPART:
                 $paramsKey = RequestOptions::MULTIPART;
                 break;
             default:
@@ -338,10 +342,10 @@ class Twitter
      */
     private function request(string $url, array $parameters, string $method)
     {
-        $responseFormat = $parameters[self::KEY_RESPONSE_FORMAT] ?? self::RESPONSE_FORMAT_OBJECT;
-        $requestFormat = $parameters[self::KEY_REQUEST_FORMAT] ?? $responseFormat;
+        $requestFormat = $parameters[self::KEY_REQUEST_FORMAT] ?? null;
+        $responseFormat = $parameters[self::KEY_RESPONSE_FORMAT] ?? $parameters[self::KEY_FORMAT] ?? self::RESPONSE_FORMAT_OBJECT;
 
-        unset($parameters[self::KEY_RESPONSE_FORMAT]);
+        unset($parameters[self::KEY_REQUEST_FORMAT], $parameters[self::KEY_RESPONSE_FORMAT], $parameters[self::KEY_FORMAT]);
 
         $requestOptions = $this->getRequestOptions($parameters, $method, $requestFormat);
         $response = $this->httpClient->request($method, $url, $requestOptions);


### PR DESCRIPTION
Follow-up to fix unsupported media type (#295)

---

With this change the following works:
```php
$data = [
        'format' => 'json',
        'request_format' => 'json',
        'event' => [
            'type' => 'message_create',
            'message_create' => [
                'target' => [
                    'recipient_id' => $recipient
                ],
                'message_data' => [
                    'text' => 'Happy New Year!'
                ]
            ]
        ]
    ];

    try
    {
        $response = Twitter::post('direct_messages/events/new', $data);
    } catch (Exception $exception) {
        // ...
    }
```
or 
```php
$data = [
        'format' => 'json',
        'event' => [
            'type' => 'message_create',
            'message_create' => [
                'target' => [
                    'recipient_id' => $recipient
                ],
                'message_data' => [
                    'text' => 'Happy New Year!'
                ]
            ]
        ]
    ];

    try
    {
        $response = Twitter::postDm($data);
    } catch (Exception $exception) {
        // ...
    }
```

**Note:** `request_format` must be explicitly set when calling `Twitter::post()` directly.