### PR TITLE
Switch getUsersLookup() to use POST method

### DIFF
--- a/src/Thujohn/Twitter/Traits/UserTrait.php
+++ b/src/Thujohn/Twitter/Traits/UserTrait.php
@@ -22,6 +22,26 @@ trait UserTrait
 
         return $this->get('users/lookup', $parameters);
     }
+    
+    /**
+     * Returns fully-hydrated user objects for up to 100 users per request, as specified by comma-separated values passed to the user_id and/or screen_name parameters.
+     *
+     * For a large requests of 10-100 users, twitter suggests to use POST request. GET request gives errors for large requests.
+     *
+     *  Parameters :
+     * - user_id
+     * - screen_name
+     * - include_entities (0|1)
+     */
+
+    public function postUsersLookup($parameters = [])
+    {
+        if (!array_key_exists('user_id', $parameters) && !array_key_exists('screen_name', $parameters)) {
+            throw new BadMethodCallException('Parameter required missing : user_id or screen_name');
+        }
+
+        return $this->post('users/lookup', $parameters);
+    }
 
     /**
      * Returns a variety of information about the user specified by the required user_id or screen_name parameter. The author’s most recent Tweet will be returned inline when possible.

--- a/src/Thujohn/Twitter/Traits/UserTrait.php
+++ b/src/Thujohn/Twitter/Traits/UserTrait.php
@@ -48,6 +48,7 @@ trait UserTrait
      * - screen_name
      * - include_entities (0|1)
      */
+    
     public function getUsers($parameters = [])
     {
         if (!array_key_exists('user_id', $parameters) && !array_key_exists('screen_name', $parameters)) {

--- a/src/Thujohn/Twitter/Traits/UserTrait.php
+++ b/src/Thujohn/Twitter/Traits/UserTrait.php
@@ -20,23 +20,6 @@ trait UserTrait
             throw new BadMethodCallException('Parameter required missing : user_id or screen_name');
         }
 
-        return $this->get('users/lookup', $parameters);
-    }
-    
-    /**
-     * Returns fully-hydrated user objects for up 10 to 100 users per request, as specified by comma-separated values passed to the user_id and/or screen_name parameters.
-     *
-     *  Parameters :
-     * - user_id
-     * - screen_name
-     * - include_entities (0|1)
-     */
-    public function postUsersLookup($parameters = [])
-    {
-        if (!array_key_exists('user_id', $parameters) && !array_key_exists('screen_name', $parameters)) {
-            throw new BadMethodCallException('Parameter required missing : user_id or screen_name');
-        }
-
         return $this->post('users/lookup', $parameters);
     }
 
@@ -48,7 +31,6 @@ trait UserTrait
      * - screen_name
      * - include_entities (0|1)
      */
-    
     public function getUsers($parameters = [])
     {
         if (!array_key_exists('user_id', $parameters) && !array_key_exists('screen_name', $parameters)) {

--- a/src/Thujohn/Twitter/Traits/UserTrait.php
+++ b/src/Thujohn/Twitter/Traits/UserTrait.php
@@ -26,8 +26,6 @@ trait UserTrait
     /**
      * Returns fully-hydrated user objects for up 10 to 100 users per request, as specified by comma-separated values passed to the user_id and/or screen_name parameters.
      *
-     * For a large request of 10-100 users, twitter suggests to use POST request. GET request gives errors for a large query.
-     *
      *  Parameters :
      * - user_id
      * - screen_name

--- a/src/Thujohn/Twitter/Traits/UserTrait.php
+++ b/src/Thujohn/Twitter/Traits/UserTrait.php
@@ -33,7 +33,6 @@ trait UserTrait
      * - screen_name
      * - include_entities (0|1)
      */
-
     public function postUsersLookup($parameters = [])
     {
         if (!array_key_exists('user_id', $parameters) && !array_key_exists('screen_name', $parameters)) {

--- a/src/Thujohn/Twitter/Traits/UserTrait.php
+++ b/src/Thujohn/Twitter/Traits/UserTrait.php
@@ -6,8 +6,9 @@ use BadMethodCallException;
 
 trait UserTrait
 {
-    /**
-     * Returns fully-hydrated user objects for up to 10 users per request, as specified by comma-separated values passed to the user_id and/or screen_name parameters.
+   /**
+     * Returns fully-hydrated user objects for up to 100 users per request, as specified by comma-separated values passed to the user_id and/or screen_name parameters.
+     * POST request is used instead of GET as it throws an error on large requests.
      *
      *  Parameters :
      * - user_id


### PR DESCRIPTION
Added postUsersLookup() method for larger requests of 10 to 100 accounts, Twitter recommends using POST instead of GET for large requests as GET returns if you query 10+ users.