### PR TITLE
In linkify() if $tweet['text'] is not found, use $tweet['full_text']

### DIFF
--- a/src/Thujohn/Twitter/Twitter.php
+++ b/src/Thujohn/Twitter/Twitter.php
@@ -373,7 +373,7 @@ class Twitter extends tmhOAuth
                 return '<a href="'.$url.'" target="_blank" rel="nofollow">'."$input</a>";
             }, $text);
         } else {
-            $text = $tweet['text'];
+            $text = $tweet['text'] ?? $tweet['full_text'];
             $entities = $tweet['entities'];
 
             $search = [];


### PR DESCRIPTION
Fixes #304