### PR TITLE
Fixed: Class 'Input' not found

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,9 +345,9 @@ Route::get('twitter/callback', ['as' => 'twitter.callback', function() {
 
 		$oauth_verifier = false;
 
-		if (Input::has('oauth_verifier'))
+		if (Request::has('oauth_verifier'))
 		{
-			$oauth_verifier = Input::get('oauth_verifier');
+			$oauth_verifier = Request::get('oauth_verifier');
 			// getAccessToken() will reset the token for you
 			$token = Twitter::getAccessToken($oauth_verifier);
 		}


### PR DESCRIPTION
As per docs: https://laravel.com/docs/6.x/upgrade#the-input-facade
Input no longer exists. Either use the Request facade or alias that instead of Input.

[Source](https://laracasts.com/discuss/channels/laravel/laravel-6-class-illuminatesupportfacadesinput-not-found?reply=534800)