### PR TITLE
Convert new line character (\n) to HTML break line (<br>)

### DIFF
--- a/src/Thujohn/Twitter/Utils.php
+++ b/src/Thujohn/Twitter/Utils.php
@@ -72,7 +72,7 @@ abstract class Utils
 
         // Convert new line character (\n) to HTML break line (<br>)
         // Example : https://twitter.com/GNFI/status/1350333230365483009
-        $text = nl2br($text); 
+        $text = nl2br($text);
 
         // Remove multiple spaces
         $text = preg_replace('/\s+/', ' ', $text);

--- a/src/Thujohn/Twitter/Utils.php
+++ b/src/Thujohn/Twitter/Utils.php
@@ -70,6 +70,10 @@ abstract class Utils
         // Long URL
         $text = preg_replace('/'.$patterns['long_url'].'/', '>\\3...\\5\\6<', $text);
 
+        // Convert new line character (\n) to HTML break line (<br>)
+        // Example : https://twitter.com/GNFI/status/1350333230365483009
+        $text = nl2br($text); 
+
         // Remove multiple spaces
         $text = preg_replace('/\s+/', ' ', $text);
 


### PR DESCRIPTION
Convert new line character (`\n`) to HTML break line (`<br>`)
Example : https://twitter.com/GNFI/status/1350333230365483009

Before : 
![image](https://user-images.githubusercontent.com/3906712/104805736-d913d080-5804-11eb-8f5d-dfc4060fca80.png)

After :
![image](https://user-images.githubusercontent.com/3906712/104805742-e03ade80-5804-11eb-9674-9f6fe5044211.png)