### PR TITLE
fix: ensure Twitter facade resolves as singleton (fixes #349)

### DIFF
--- a/src/ApiV1/Service/Twitter.php
+++ b/src/ApiV1/Service/Twitter.php
@@ -52,10 +52,7 @@ class Twitter implements TwitterContract
 
     public function __construct(Querier $querier)
     {
-        $config = $querier->getConfiguration();
-        $this->config = $config;
-        $this->querier = $querier;
-        $this->debug = $config->isDebugMode();
+        $this->setQuerier($querier);
     }
 
     /**
@@ -67,8 +64,13 @@ class Twitter implements TwitterContract
         ?string $consumerKey = null,
         ?string $consumerSecret = null
     ): self {
-        return new self(
-            $this->querier->usingCredentials($accessToken, $accessTokenSecret, $consumerKey, $consumerSecret)
+        return $this->setQuerier(
+            $this->querier->usingCredentials(
+                $accessToken,
+                $accessTokenSecret,
+                $consumerKey,
+                $consumerSecret
+            )
         );
     }
 
@@ -77,7 +79,7 @@ class Twitter implements TwitterContract
      */
     public function usingConfiguration(Configuration $configuration): self
     {
-        return new self($this->querier->usingConfiguration($configuration));
+        return $this->setQuerier($this->querier->usingConfiguration($configuration));
     }
 
     /**
@@ -135,5 +137,15 @@ class Twitter implements TwitterContract
     public function delete(string $endpoint, array $parameters = [])
     {
         return $this->query($endpoint, self::REQUEST_METHOD_DELETE, $parameters);
+    }
+
+    private function setQuerier(Querier $querier): self
+    {
+        $config = $querier->getConfiguration();
+        $this->config = $config;
+        $this->querier = $querier;
+        $this->debug = $config->isDebugMode();
+
+        return $this;
     }
 }

--- a/src/Concern/ApiV2Behavior.php
+++ b/src/Concern/ApiV2Behavior.php
@@ -9,7 +9,7 @@ use Atymic\Twitter\Twitter;
 
 trait ApiV2Behavior
 {
-    abstract protected function getQuerier(): Querier;
+    abstract public function getQuerier(): Querier;
 
     protected function implodeParamValues(array $paramValues): string
     {

--- a/src/Contract/Twitter.php
+++ b/src/Contract/Twitter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Atymic\Twitter\Contract;
 
+use Atymic\Twitter\Contract\Querier as QuerierContract;
 use Atymic\Twitter\Exception\ClientException;
 use Atymic\Twitter\Twitter as BaseTwitterContract;
 
@@ -130,4 +131,6 @@ interface Twitter extends BaseTwitterContract
      * @see https://developer.twitter.com/en/docs/twitter-api/tweets/hide-replies/api-reference/put-tweets-id-hidden
      */
     public function hideTweet(string $tweetId, bool $hidden = true);
+
+    public function getQuerier(): QuerierContract;
 }

--- a/src/Service/Accessor.php
+++ b/src/Service/Accessor.php
@@ -45,10 +45,10 @@ final class Accessor implements TwitterContract
         ?string $consumerKey = null,
         ?string $consumerSecret = null
     ): self {
-        return new self(
-            $this->getQuerier()
-                ->usingCredentials($accessToken, $accessTokenSecret, $consumerKey, $consumerSecret)
-        );
+        $this->querier = $this->getQuerier()
+            ->usingCredentials($accessToken, $accessTokenSecret, $consumerKey, $consumerSecret);
+
+        return $this;
     }
 
     /**
@@ -57,13 +57,13 @@ final class Accessor implements TwitterContract
      */
     public function usingConfiguration(Configuration $configuration): self
     {
-        return new self(
-            $this->getQuerier()
-                ->usingConfiguration($configuration)
-        );
+        $this->querier = $this->getQuerier()
+            ->usingConfiguration($configuration);
+
+        return $this;
     }
 
-    protected function getQuerier(): QuerierContract
+    public function getQuerier(): QuerierContract
     {
         return $this->querier;
     }

--- a/tests/Unit/AccessorTestCase.php
+++ b/tests/Unit/AccessorTestCase.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Atymic\Twitter\Tests\Unit;
 
+use Atymic\Twitter\Contract\Configuration;
 use Atymic\Twitter\Contract\Querier;
 use Atymic\Twitter\Tests\Integration\Laravel\TestCase;
 use Exception;
@@ -20,6 +21,11 @@ abstract class AccessorTestCase extends TestCase
     protected const ARBITRARY_RESPONSE = ['response'];
 
     /**
+     * @var ObjectProphecy|Configuration
+     */
+    protected ObjectProphecy $config;
+
+    /**
      * @var ObjectProphecy|Querier
      */
     protected ObjectProphecy $querier;
@@ -29,6 +35,7 @@ abstract class AccessorTestCase extends TestCase
      */
     protected function setUp(): void
     {
+        $this->config = $this->prophesize(Configuration::class);
         $this->querier = $this->prophesize(Querier::class);
 
         $this->querier
@@ -43,5 +50,8 @@ abstract class AccessorTestCase extends TestCase
         $this->querier
             ->withOAuth2Client(Argument::cetera())
             ->willReturn($this->querier);
+        $this->querier
+            ->getConfiguration()
+            ->willReturn($this->config->reveal());
     }
 }

--- a/tests/Unit/Service/AccessorTest.php
+++ b/tests/Unit/Service/AccessorTest.php
@@ -7,7 +7,6 @@ declare(strict_types=1);
 
 namespace Atymic\Twitter\Tests\Unit\Service;
 
-use Atymic\Twitter\Contract\Configuration;
 use Atymic\Twitter\Contract\Twitter;
 use Atymic\Twitter\Service\Accessor;
 use Atymic\Twitter\Tests\Unit\AccessorTestCase;
@@ -43,12 +42,29 @@ final class AccessorTest extends AccessorTestCase
     {
         $accessToken = 'token';
         $accessTokenSecret = 'secret';
+        $consumerKey = 'consumer-key';
+        $consumerSecret = 'consumer-secret';
+
+        $this->config->getAccessToken()
+            ->willReturn($accessToken);
+        $this->config->getAccessTokenSecret()
+            ->willReturn($accessTokenSecret);
+        $this->config->getConsumerKey()
+            ->willReturn($consumerKey);
+        $this->config->getConsumerSecret()
+            ->willReturn($consumerSecret);
 
         $result = $this->subject
-            ->usingCredentials($accessToken, $accessTokenSecret);
+            ->usingCredentials($accessToken, $accessTokenSecret, $consumerKey, $consumerSecret);
+        $resultConfig = $result->getQuerier()
+            ->getConfiguration();
 
         self::assertInstanceOf(Twitter::class, $result);
-        self::assertNotSame($result, $this->subject);
+        self::assertSame($result, $this->subject);
+        self::assertSame($accessToken, $resultConfig->getAccessToken());
+        self::assertSame($accessTokenSecret, $resultConfig->getAccessTokenSecret());
+        self::assertSame($consumerKey, $resultConfig->getConsumerKey());
+        self::assertSame($consumerSecret, $resultConfig->getConsumerSecret());
     }
 
     /**
@@ -59,16 +75,18 @@ final class AccessorTest extends AccessorTestCase
      */
     public function testUsingConfiguration(): void
     {
-        /**
-         * @var Configuration $config
-         */
-        $config = $this->prophesize(Configuration::class)
-            ->reveal();
+        $accessToken = 'access-token';
+
+        $this->config->getAccessToken()
+            ->willReturn($accessToken);
 
         $result = $this->subject
-            ->usingConfiguration($config);
+            ->usingConfiguration($this->config->reveal());
+        $resultConfig = $result->getQuerier()
+            ->getConfiguration();
 
         self::assertInstanceOf(Twitter::class, $result);
-        self::assertNotSame($result, $this->subject);
+        self::assertSame($result, $this->subject);
+        self::assertSame($resultConfig->getAccessToken(), $accessToken);
     }
 }


### PR DESCRIPTION
This ensures that the same instance of accessor is resolved by the twitter facade/contract.

