### PR TITLE
fix: unable to switch API version on service #355

### DIFF
--- a/src/ApiV1/Service/Twitter.php
+++ b/src/ApiV1/Service/Twitter.php
@@ -20,10 +20,10 @@ use Atymic\Twitter\ApiV1\Traits\SearchTrait;
 use Atymic\Twitter\ApiV1\Traits\StatusTrait;
 use Atymic\Twitter\ApiV1\Traits\TrendTrait;
 use Atymic\Twitter\ApiV1\Traits\UserTrait;
+use Atymic\Twitter\Concern\HotSwapper;
 use Atymic\Twitter\Contract\Configuration;
 use Atymic\Twitter\Contract\Querier;
 use Atymic\Twitter\Exception\ClientException as TwitterClientException;
-use InvalidArgumentException;
 
 class Twitter implements TwitterContract
 {
@@ -42,6 +42,7 @@ class Twitter implements TwitterContract
     use TrendTrait;
     use UserTrait;
     use AuthTrait;
+    use HotSwapper;
 
     private const DEFAULT_EXTENSION = 'json';
     private const URL_FORMAT = 'https://%s/%s/%s.%s';
@@ -55,31 +56,9 @@ class Twitter implements TwitterContract
         $this->setQuerier($querier);
     }
 
-    /**
-     * @throws InvalidArgumentException
-     */
-    public function usingCredentials(
-        string $accessToken,
-        string $accessTokenSecret,
-        ?string $consumerKey = null,
-        ?string $consumerSecret = null
-    ): self {
-        return $this->setQuerier(
-            $this->querier->usingCredentials(
-                $accessToken,
-                $accessTokenSecret,
-                $consumerKey,
-                $consumerSecret
-            )
-        );
-    }
-
-    /**
-     * @throws InvalidArgumentException
-     */
-    public function usingConfiguration(Configuration $configuration): self
+    public function getQuerier(): Querier
     {
-        return $this->setQuerier($this->querier->usingConfiguration($configuration));
+        return $this->querier;
     }
 
     /**

--- a/src/Concern/HotSwapper.php
+++ b/src/Concern/HotSwapper.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atymic\Twitter\Concern;
+
+use Atymic\Twitter\Contract\Configuration;
+use Atymic\Twitter\Contract\Querier;
+use Atymic\Twitter\Twitter;
+use InvalidArgumentException;
+
+trait HotSwapper
+{
+    abstract public function getQuerier(): Querier;
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    public function usingCredentials(
+        string $accessToken,
+        string $accessTokenSecret,
+        ?string $consumerKey = null,
+        ?string $consumerSecret = null
+    ): Twitter {
+        return $this->setQuerier(
+            $this->getQuerier()
+                ->usingCredentials(
+                    $accessToken,
+                    $accessTokenSecret,
+                    $consumerKey,
+                    $consumerSecret
+                )
+        );
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    public function usingConfiguration(Configuration $configuration): Twitter
+    {
+        return $this->setQuerier(
+            $this->getQuerier()
+                ->usingConfiguration($configuration)
+        );
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    public function forApiV1(): Twitter
+    {
+        $config = $this->getQuerier()
+            ->getConfiguration();
+
+        return $this->usingConfiguration($config->forApiV1());
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    public function forApiV2(): Twitter
+    {
+        $config = $this->getQuerier()
+            ->getConfiguration();
+
+        return $this->usingConfiguration($config->forApiV2());
+    }
+}

--- a/src/Service/Accessor.php
+++ b/src/Service/Accessor.php
@@ -7,15 +7,14 @@ namespace Atymic\Twitter\Service;
 use Atymic\Twitter\Concern\FilteredStream;
 use Atymic\Twitter\Concern\Follows;
 use Atymic\Twitter\Concern\HideReplies;
+use Atymic\Twitter\Concern\HotSwapper;
 use Atymic\Twitter\Concern\SampledStream;
 use Atymic\Twitter\Concern\SearchTweets;
 use Atymic\Twitter\Concern\Timelines;
 use Atymic\Twitter\Concern\TweetLookup;
 use Atymic\Twitter\Concern\UserLookup;
-use Atymic\Twitter\Contract\Configuration;
 use Atymic\Twitter\Contract\Querier as QuerierContract;
 use Atymic\Twitter\Contract\Twitter as TwitterContract;
-use InvalidArgumentException;
 
 final class Accessor implements TwitterContract
 {
@@ -27,6 +26,7 @@ final class Accessor implements TwitterContract
     use UserLookup;
     use Follows;
     use HideReplies;
+    use HotSwapper;
 
     private QuerierContract $querier;
 
@@ -35,36 +35,15 @@ final class Accessor implements TwitterContract
         $this->querier = $querier;
     }
 
-    /**
-     * @throws InvalidArgumentException
-     * @see QuerierContract::usingCredentials()
-     */
-    public function usingCredentials(
-        string $accessToken,
-        string $accessTokenSecret,
-        ?string $consumerKey = null,
-        ?string $consumerSecret = null
-    ): self {
-        $this->querier = $this->getQuerier()
-            ->usingCredentials($accessToken, $accessTokenSecret, $consumerKey, $consumerSecret);
-
-        return $this;
-    }
-
-    /**
-     * @throws InvalidArgumentException
-     * @see QuerierContract::usingConfiguration()
-     */
-    public function usingConfiguration(Configuration $configuration): self
-    {
-        $this->querier = $this->getQuerier()
-            ->usingConfiguration($configuration);
-
-        return $this;
-    }
-
     public function getQuerier(): QuerierContract
     {
         return $this->querier;
+    }
+
+    private function setQuerier(QuerierContract $querier): self
+    {
+        $this->querier = $querier;
+
+        return $this;
     }
 }

--- a/src/Twitter.php
+++ b/src/Twitter.php
@@ -51,4 +51,14 @@ interface Twitter
      * @see Querier::usingConfiguration()
      */
     public function usingConfiguration(Configuration $configuration): self;
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    public function forApiV1(): self;
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    public function forApiV2(): self;
 }

--- a/tests/Unit/Service/AccessorTest.php
+++ b/tests/Unit/Service/AccessorTest.php
@@ -33,7 +33,7 @@ final class AccessorTest extends AccessorTestCase
     }
 
     /**
-     * @covers ::usingCredentials
+     * @covers \Atymic\Twitter\Concern\HotSwapper::usingCredentials
      * @covers ::__construct
      * @covers ::getQuerier
      * @throws Exception
@@ -68,7 +68,7 @@ final class AccessorTest extends AccessorTestCase
     }
 
     /**
-     * @covers ::usingConfiguration
+     * @covers \Atymic\Twitter\Concern\HotSwapper::usingConfiguration
      * @covers ::__construct
      * @covers ::getQuerier
      * @throws Exception


### PR DESCRIPTION
This exposes `forApiV1()` and `forApiV2` methods which were not previously available on Twitter service.

Fixes: #355 