### PR TITLE
fix: hotswapping methods forApiV1() and forApiV2()

### DIFF
--- a/src/Concern/HotSwapper.php
+++ b/src/Concern/HotSwapper.php
@@ -4,9 +4,13 @@ declare(strict_types=1);
 
 namespace Atymic\Twitter\Concern;
 
+use Atymic\Twitter\ApiV1\Contract\Twitter as TwitterV1Contract;
+use Atymic\Twitter\ApiV1\Service\Twitter as TwitterV1;
 use Atymic\Twitter\Contract\Configuration;
 use Atymic\Twitter\Contract\Querier;
-use Atymic\Twitter\Twitter;
+use Atymic\Twitter\Contract\Twitter as TwitterV2Contract;
+use Atymic\Twitter\Service\Accessor as TwitterV2;
+use Atymic\Twitter\Twitter as TwitterBaseContract;
 use InvalidArgumentException;
 
 trait HotSwapper
@@ -21,7 +25,7 @@ trait HotSwapper
         string $accessTokenSecret,
         ?string $consumerKey = null,
         ?string $consumerSecret = null
-    ): Twitter {
+    ): TwitterBaseContract {
         return $this->setQuerier(
             $this->getQuerier()
                 ->usingCredentials(
@@ -36,7 +40,7 @@ trait HotSwapper
     /**
      * @throws InvalidArgumentException
      */
-    public function usingConfiguration(Configuration $configuration): Twitter
+    public function usingConfiguration(Configuration $configuration): TwitterBaseContract
     {
         return $this->setQuerier(
             $this->getQuerier()
@@ -47,24 +51,30 @@ trait HotSwapper
     /**
      * @throws InvalidArgumentException
      */
-    public function forApiV1(): Twitter
+    public function forApiV1(): TwitterV1Contract
     {
         $config = $this->getQuerier()
-            ->getConfiguration();
-        $instance = clone $this;
+            ->getConfiguration()
+            ->forApiV1();
 
-        return $instance->usingConfiguration($config->forApiV1());
+        return new TwitterV1(
+            $this->getQuerier()
+                ->usingConfiguration($config)
+        );
     }
 
     /**
      * @throws InvalidArgumentException
      */
-    public function forApiV2(): Twitter
+    public function forApiV2(): TwitterV2Contract
     {
         $config = $this->getQuerier()
-            ->getConfiguration();
-        $instance = clone $this;
+            ->getConfiguration()
+            ->forApiV2();
 
-        return $instance->usingConfiguration($config->forApiV2());
+        return new TwitterV2(
+            $this->getQuerier()
+                ->usingConfiguration($config)
+        );
     }
 }

--- a/src/Twitter.php
+++ b/src/Twitter.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Atymic\Twitter;
 
+use Atymic\Twitter\ApiV1\Contract\Twitter as TwitterV1Contract;
 use Atymic\Twitter\Contract\Configuration;
 use Atymic\Twitter\Contract\Querier;
+use Atymic\Twitter\Contract\Twitter as TwitterV2Contract;
 use InvalidArgumentException;
 
 interface Twitter
@@ -57,12 +59,12 @@ interface Twitter
      *
      * @throws InvalidArgumentException
      */
-    public function forApiV1(): self;
+    public function forApiV1(): TwitterV1Contract;
 
     /**
      * Get an instance of Twitter configured for API v2.
      *
      * @throws InvalidArgumentException
      */
-    public function forApiV2(): self;
+    public function forApiV2(): TwitterV2Contract;
 }

--- a/tests/Unit/AccessorTestCase.php
+++ b/tests/Unit/AccessorTestCase.php
@@ -38,6 +38,11 @@ abstract class AccessorTestCase extends TestCase
         $this->config = $this->prophesize(Configuration::class);
         $this->querier = $this->prophesize(Querier::class);
 
+        $this->config->getApiVersion()
+            ->willReturn('1.1');
+        $this->config->isDebugMode()
+            ->willReturn(true);
+
         $this->querier
             ->usingCredentials(Argument::cetera())
             ->willReturn($this->querier);

--- a/tests/Unit/Concern/HotSwapperTest.php
+++ b/tests/Unit/Concern/HotSwapperTest.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * @noinspection PhpParamsInspection
+ */
+
+declare(strict_types=1);
+
+namespace Atymic\Twitter\Tests\Unit\Concern;
+
+use Atymic\Twitter\ApiV1\Contract\Twitter as TwitterV1Contract;
+use Atymic\Twitter\Concern\HotSwapper;
+use Atymic\Twitter\Contract\Configuration;
+use Atymic\Twitter\Contract\Twitter as TwitterV2Contract;
+use Exception;
+use Prophecy\Prophecy\ObjectProphecy;
+
+final class HotSwapperTest extends ConcernTestCase
+{
+    /**
+     * @throws Exception
+     */
+    public function testForApiV1(): void
+    {
+        /** @var Configuration|ObjectProphecy $v1Config */
+        $v1Config = $this->prophesize(Configuration::class);
+        $v1Config->getApiVersion()
+            ->willReturn('1.1');
+
+        $this->config->forApiV1()
+            ->willReturn($v1Config->reveal());
+        $this->config->forApiV2()
+            ->shouldNotBeCalled();
+
+        $this->querier->usingConfiguration($v1Config)
+            ->shouldBeCalledTimes(1)
+            ->willReturn($this->querier->reveal());
+
+        $result = $this->subject->forApiV1();
+
+        self::assertInstanceOf(TwitterV1Contract::class, $result);
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testForApiV2(): void
+    {
+        /** @var Configuration|ObjectProphecy $v2Config */
+        $v2Config = $this->prophesize(Configuration::class);
+        $v2Config->getApiVersion()
+            ->willReturn('2');
+
+        $this->config->forApiV1()
+            ->shouldNotBeCalled();
+        $this->config->forApiV2()
+            ->willReturn($v2Config->reveal());
+
+        $this->querier->usingConfiguration($v2Config)
+            ->shouldBeCalledTimes(1)
+            ->willReturn($this->querier->reveal());
+
+        $result = $this->subject->forApiV2();
+
+        self::assertInstanceOf(TwitterV2Contract::class, $result);
+    }
+
+    protected function getTraitName(): string
+    {
+        return HotSwapper::class;
+    }
+}


### PR DESCRIPTION
Follow-up to finally fix #355 