### PR TITLE
Ability to get the last response

### DIFF
--- a/src/Contract/Http/SyncClient.php
+++ b/src/Contract/Http/SyncClient.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Atymic\Twitter\Contract\Http;
 
 use Atymic\Twitter\Exception\ClientException;
+use Psr\Http\Message\ResponseInterface;
 
 interface SyncClient extends Client
 {
@@ -13,4 +14,9 @@ interface SyncClient extends Client
      * @throws ClientException
      */
     public function request(string $method, string $url, array $data = []);
+
+    /**
+     * @return ResponseInterface|null
+     */
+    public function getResponse();
 }

--- a/src/Contract/Http/SyncClient.php
+++ b/src/Contract/Http/SyncClient.php
@@ -18,5 +18,5 @@ interface SyncClient extends Client
     /**
      * @return ResponseInterface|null
      */
-    public function getResponse();
+    public function getLastResponse();
 }

--- a/src/Contract/Querier.php
+++ b/src/Contract/Querier.php
@@ -6,6 +6,7 @@ namespace Atymic\Twitter\Contract;
 
 use Atymic\Twitter\Contract\Http\AsyncClient;
 use Atymic\Twitter\Contract\Http\Client as HttpClient;
+use Atymic\Twitter\Contract\Http\SyncClient;
 use Atymic\Twitter\Exception\ClientException as TwitterClientException;
 use GuzzleHttp\RequestOptions;
 use InvalidArgumentException;
@@ -105,4 +106,6 @@ interface Querier
     public function getStream(string $endpoint, callable $onData, array $parameters = []): void;
 
     public function getConfiguration(): Configuration;
+
+    public function getSyncClient(): SyncClient;
 }

--- a/src/Contract/Querier.php
+++ b/src/Contract/Querier.php
@@ -108,4 +108,6 @@ interface Querier
     public function getConfiguration(): Configuration;
 
     public function getSyncClient(): SyncClient;
+
+    public function getAsyncClient(): AsyncClient;
 }

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -12,6 +12,7 @@ use Atymic\Twitter\Exception\Request\NotFoundException;
 use Atymic\Twitter\Exception\Request\RateLimitedException;
 use Atymic\Twitter\Exception\Request\UnauthorizedRequestException;
 use GuzzleHttp\Psr7\Response;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Log\InvalidArgumentException as InvalidLogArgumentException;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
@@ -21,6 +22,7 @@ abstract class Client implements ClientContract
 {
     protected bool $debug;
     protected ?LoggerInterface $logger = null;
+    protected ?ResponseInterface $response = null;
 
     public function __construct(bool $debug, ?LoggerInterface $logger)
     {
@@ -61,6 +63,7 @@ abstract class Client implements ClientContract
     {
         /** @var null|Response $response */
         $response = method_exists($exception, 'getResponse') ? $exception->getResponse() : null;
+        $this->response = $response;
         $responseCode = $response !== null ? $response->getStatusCode() : null;
 
         switch ($responseCode) {

--- a/src/Http/Client/SyncClient.php
+++ b/src/Http/Client/SyncClient.php
@@ -58,7 +58,7 @@ final class SyncClient extends Client implements SyncClientContract
     /**
      * @return ResponseInterface|null
      */
-    public function getResponse(): ?ResponseInterface
+    public function getLastResponse(): ?ResponseInterface
     {
         return $this->response;
     }

--- a/src/Http/Client/SyncClient.php
+++ b/src/Http/Client/SyncClient.php
@@ -46,11 +46,21 @@ final class SyncClient extends Client implements SyncClientContract
             );
 
             $requestOptions = $this->getRequestOptions($method, $data, $requestFormat);
+            $response = $this->client->request($method, $url, $requestOptions);
+            $this->response = $response;
 
-            return $this->formatResponse($this->client->request($method, $url, $requestOptions), $responseFormat);
+            return $this->formatResponse($response, $responseFormat);
         } catch (Throwable $exception) {
             throw $this->deduceClientException($exception);
         }
+    }
+
+    /**
+     * @return ResponseInterface|null
+     */
+    public function getResponse(): ?ResponseInterface
+    {
+        return $this->response;
     }
 
     private function getRequestOptions(string $requestMethod, array $params, ?string $requestFormat): array

--- a/src/Service/Querier.php
+++ b/src/Service/Querier.php
@@ -61,6 +61,14 @@ final class Querier implements QuerierContract
 
     /**
      * @codeCoverageIgnore
+     */
+    public function getAsyncClient(): AsyncClient
+    {
+        return $this->asyncClient;
+    }
+
+    /**
+     * @codeCoverageIgnore
      * @throws InvalidArgumentException
      */
     public function usingCredentials(

--- a/src/Service/Querier.php
+++ b/src/Service/Querier.php
@@ -53,6 +53,14 @@ final class Querier implements QuerierContract
 
     /**
      * @codeCoverageIgnore
+     */
+    public function getSyncClient(): SyncClient
+    {
+        return $this->syncClient;
+    }
+
+    /**
+     * @codeCoverageIgnore
      * @throws InvalidArgumentException
      */
     public function usingCredentials(

--- a/tests/Unit/Http/Client/SyncClientTest.php
+++ b/tests/Unit/Http/Client/SyncClientTest.php
@@ -80,7 +80,7 @@ final class SyncClientTest extends TestCase
 
         self::assertInstanceOf(stdClass::class, $result);
         self::assertSame('bar', $result->foo);
-        self::assertInstanceOf(ResponseInterface::class, $this->subject->getResponse());
+        self::assertInstanceOf(ResponseInterface::class, $this->subject->getLastResponse());
     }
 
     /**

--- a/tests/Unit/Http/Client/SyncClientTest.php
+++ b/tests/Unit/Http/Client/SyncClientTest.php
@@ -80,6 +80,7 @@ final class SyncClientTest extends TestCase
 
         self::assertInstanceOf(stdClass::class, $result);
         self::assertSame('bar', $result->foo);
+        self::assertInstanceOf(ResponseInterface::class, $this->subject->getResponse());
     }
 
     /**

--- a/tests/Unit/Service/QuerierTest.php
+++ b/tests/Unit/Service/QuerierTest.php
@@ -144,7 +144,6 @@ final class QuerierTest extends TestCase
         $result = $this->subject->query($endpoint, $method, $params, $multipart, $extension);
 
         self::assertSame($response, $result);
-        self::assertInstanceOf(SyncClient::class, $this->subject->getSyncClient());
     }
 
     /**

--- a/tests/Unit/Service/QuerierTest.php
+++ b/tests/Unit/Service/QuerierTest.php
@@ -144,6 +144,7 @@ final class QuerierTest extends TestCase
         $result = $this->subject->query($endpoint, $method, $params, $multipart, $extension);
 
         self::assertSame($response, $result);
+        self::assertInstanceOf(SyncClient::class, $this->subject->getSyncClient());
     }
 
     /**


### PR DESCRIPTION
Fixes #358 

Added a `getSyncClient()` method to `Querier` and added a `getResponse()` method to `SyncClient`. This allows you to access the last response including the headers.

I did not add anything to `AsyncClient` since I wasn't sure how that would work since it returns a Promise.
I wasn't sure the best way to update the tests so let me know if I should change anything. I wanted to test that the response is still set when there is an exception but couldn't figure out how to test that with the mocked objects.