### PR TITLE
Expose new tweet count endpoints, ref: #365

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,7 +524,7 @@ public function searchRecent(string $query): JsonResponse
 
 ###### Call a newly added endpoint:
 
-Since Twitter API v2 is being actively developed, you might need to call an endpoint we did not explicitly document in
+Since Twitter API v2 is in active development, you might need to call an endpoint we did not explicitly document in
 the "Functions" section above. Here is an example of how you may use this package to make calls to any newly added
 endpoints. Here we use the newly added "recent count" endpoint.
 

--- a/README.md
+++ b/README.md
@@ -1,17 +1,18 @@
 # Twitter for PHP
 
-[![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE.md) 
-[![Build Status](https://img.shields.io/travis/atymic/twitter/master.svg?style=flat-square)](https://travis-ci.org/atymic/twitter) 
-[![StyleCI](https://styleci.io/repos/11009743/shield)](https://styleci.io/repos/11009743) 
-[![Latest Version on Packagist](https://img.shields.io/packagist/v/atymic/twitter.svg?style=flat-square)](https://packagist.org/packages/thujohn/twitter) 
-[![3.x Downloads](https://img.shields.io/packagist/dt/atymic/twitter.svg?style=flat-square&label=3.x%20downloads)](https://packagist.org/packages/atymic/twitter) 
-[![2.x Downloads](https://img.shields.io/packagist/dt/thujohn/twitter.svg?style=flat-square&label=2.x%20downloads)](https://packagist.org/packages/thujohn/twitter) 
+[![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE.md)
+[![Build Status](https://img.shields.io/travis/atymic/twitter/master.svg?style=flat-square)](https://travis-ci.org/atymic/twitter)
+[![StyleCI](https://styleci.io/repos/11009743/shield)](https://styleci.io/repos/11009743)
+[![Latest Version on Packagist](https://img.shields.io/packagist/v/atymic/twitter.svg?style=flat-square)](https://packagist.org/packages/thujohn/twitter)
+[![3.x Downloads](https://img.shields.io/packagist/dt/atymic/twitter.svg?style=flat-square&label=3.x%20downloads)](https://packagist.org/packages/atymic/twitter)
+[![2.x Downloads](https://img.shields.io/packagist/dt/thujohn/twitter.svg?style=flat-square&label=2.x%20downloads)](https://packagist.org/packages/thujohn/twitter)
 ![GitHub Release Date](https://img.shields.io/github/release-date/atymic/twitter?label=latest%20release&style=flat-square)
 
-Twitter API for Laravel 6.x, 7.x, 8.x (and new versions as they are released).
-Also supports other frameworks via PHP-DI (or feel free to add support for your framework via PR)
+Twitter API for Laravel 6.x, 7.x, 8.x (and new versions as they are released). Also supports other frameworks via
+PHP-DI (or feel free to add support for your framework via PR)
 
-You need to create an application and create your access token in the [Application Management](https://apps.twitter.com/).
+You need to create an application and create your access token in
+the [Application Management](https://apps.twitter.com/).
 
 ## Installation
 
@@ -19,9 +20,9 @@ You need to create an application and create your access token in the [Applicati
 composer require atymic/twitter
 ```
 
-## Laravel Configuration 
+## Laravel Configuration
 
-Just set the below environment variables in your `.env`. 
+Just set the below environment variables in your `.env`.
 
 ```
 TWITTER_CONSUMER_KEY=
@@ -34,19 +35,20 @@ TWITTER_API_VERSION=
 ### Advanced Laravel configuration
 
 Run `php artisan vendor:publish --provider="Atymic\Twitter\ServiceProvider\LaravelServiceProvider"`
+
 ```
 /config/twitter.php
 ```
 
-# Versions 
+# Versions
 
-### 3.x 
+### 3.x
 
 3.x is the current major version, and is not backward compatible with 2.x.
 
 See the migration guide in [UPGRADE.md](./UPGRADE.md).
 
-### 2.x 
+### 2.x
 
 2.x is not longer maintained. We are not accepting bug fixes, please upgrade to 3.x
 
@@ -55,7 +57,7 @@ See the migration guide in [UPGRADE.md](./UPGRADE.md).
 ## Output format
 
 You can choose between three different output formats. By default responses will be returned as objects. To change this,
-use the `format` option in the parameters you pass to any method. 
+use the `format` option in the parameters you pass to any method.
 
 ```
 format : object|json|array (default:object)
@@ -63,10 +65,11 @@ format : object|json|array (default:object)
 
 ## Twitter API Versions
 
-To set the default twitter API version to v2 instead of the default `v1.1`, set the  `TWITTER_API_VERSION` to `2` in your `.env`.
+To set the default twitter API version to v2 instead of the default `v1.1`, set the  `TWITTER_API_VERSION` to `2` in
+your `.env`.
 
-If you have set the `v1.1` api as the default, you can use use `Twitter::forApiV2()` to get an instance of the v2 client.
-The same goes for getting a `v1` instance from a `v2` client, using `Twitter::forApiV1()`.
+If you have set the `v1.1` api as the default, you can use use `Twitter::forApiV2()` to get an instance of the v2
+client. The same goes for getting a `v1` instance from a `v2` client, using `Twitter::forApiV1()`.
 
 It is safe to call `Twitter::forApiV1()` on either a `v1` or `v2` client instance.
 
@@ -76,88 +79,136 @@ It is safe to call `Twitter::forApiV1()` on either a `v1` or `v2` client instanc
 
 #### Account
 
-* `getSettings()` - Returns settings (including current trend, geo and sleep time information) for the authenticating user.
+* `getSettings()` - Returns settings (including current trend, geo and sleep time information) for the authenticating
+  user.
 * `getCredentials()`
 * `postSettings()` - Updates the authenticating user’s settings.
-* `postSettingsDevice()` - Sets which device Twitter delivers updates to for the authenticating user. Sending none as the device parameter will disable SMS updates.
-* `postProfile()` - Sets some values that users are able to set under the “Account” tab of their settings page. Only the parameters specified will be updated. 
-* `postBackground()` - Updates the authenticating user’s profile background image. This method can also be used to enable or disable the profile background image.
-* `postProfileImage()` - Updates the authenticating user’s profile image. Note that this method expects raw multipart data, not a URL to an image.
-* `destroyUserBanner()` - Removes the uploaded profile banner for the authenticating user. Returns HTTP 200 upon success.
-* `postUserBanner()` - Uploads a profile banner on behalf of the authenticating user. For best results, upload an profile_banner_url node in their Users objects.
+* `postSettingsDevice()` - Sets which device Twitter delivers updates to for the authenticating user. Sending none as
+  the device parameter will disable SMS updates.
+* `postProfile()` - Sets some values that users are able to set under the “Account” tab of their settings page. Only the
+  parameters specified will be updated.
+* `postBackground()` - Updates the authenticating user’s profile background image. This method can also be used to
+  enable or disable the profile background image.
+* `postProfileImage()` - Updates the authenticating user’s profile image. Note that this method expects raw multipart
+  data, not a URL to an image.
+* `destroyUserBanner()` - Removes the uploaded profile banner for the authenticating user. Returns HTTP 200 upon
+  success.
+* `postUserBanner()` - Uploads a profile banner on behalf of the authenticating user. For best results, upload an
+  profile_banner_url node in their Users objects.
 
 #### Block
 
 * `getBlocks()` - Returns a collection of user objects that the authenticating user is blocking.
 * `getBlocksIds()` - Returns an array of numeric user ids the authenticating user is blocking.
-* `postBlock()` - Blocks the specified user from following the authenticating user. In addition the blocked user will not show in the authenticating users mentions or timeline (unless retweeted by another user). If a follow or friend relationship exists it is destroyed.
-* `destroyBlock()` - Un-blocks the user specified in the ID parameter for the authenticating user. Returns the un-blocked user in the requested format when successful. If relationships existed before the block was instated, they will not be restored.
+* `postBlock()` - Blocks the specified user from following the authenticating user. In addition the blocked user will
+  not show in the authenticating users mentions or timeline (unless retweeted by another user). If a follow or friend
+  relationship exists it is destroyed.
+* `destroyBlock()` - Un-blocks the user specified in the ID parameter for the authenticating user. Returns the
+  un-blocked user in the requested format when successful. If relationships existed before the block was instated, they
+  will not be restored.
 
 #### DirectMessage
 
 * `getDm()` - Returns a single direct message event, specified by an id parameter.
-* `getDms()` - Returns all Direct Message events (both sent and received) within the last 30 days. Sorted in reverse-chronological order.
-* `destroyDm()` - Destroys the direct message specified in the required ID parameter. The authenticating user must be the recipient of the specified direct message.
-* `postDm()` - Publishes a new message_create event resulting in a Direct Message sent to a specified user from the authenticating user. Returns an event if successful. Supports publishing Direct Messages with optional Quick Reply and media attachment.
+* `getDms()` - Returns all Direct Message events (both sent and received) within the last 30 days. Sorted in
+  reverse-chronological order.
+* `destroyDm()` - Destroys the direct message specified in the required ID parameter. The authenticating user must be
+  the recipient of the specified direct message.
+* `postDm()` - Publishes a new message_create event resulting in a Direct Message sent to a specified user from the
+  authenticating user. Returns an event if successful. Supports publishing Direct Messages with optional Quick Reply and
+  media attachment.
 
 #### Favorite
 
 * `getFavorites()` - Returns the 20 most recent Tweets favorited by the authenticating or specified user.
-* `destroyFavorite()` - Un-favorites the status specified in the ID parameter as the authenticating user. Returns the un-favorited status in the requested format when successful.
-* `postFavorite()` - Favorites the status specified in the ID parameter as the authenticating user. Returns the favorite status when successful.
+* `destroyFavorite()` - Un-favorites the status specified in the ID parameter as the authenticating user. Returns the
+  un-favorited status in the requested format when successful.
+* `postFavorite()` - Favorites the status specified in the ID parameter as the authenticating user. Returns the favorite
+  status when successful.
 
 #### Friendship
 
-* `getNoRters()` - Returns a collection of user_ids that the currently authenticated user does not want to receive retweets from.
+* `getNoRters()` - Returns a collection of user_ids that the currently authenticated user does not want to receive
+  retweets from.
 * `getFriendsIds()` - Returns a cursored collection of user IDs for every user following the specified user.
 * `getFollowersIds()` - Returns a cursored collection of user IDs for every user following the specified user.
-* `getFriendshipsIn()` - Returns a collection of numeric IDs for every user who has a pending request to follow the authenticating user.
-* `getFriendshipsOut()` - Returns a collection of numeric IDs for every protected user for whom the authenticating user has a pending follow request.
+* `getFriendshipsIn()` - Returns a collection of numeric IDs for every user who has a pending request to follow the
+  authenticating user.
+* `getFriendshipsOut()` - Returns a collection of numeric IDs for every protected user for whom the authenticating user
+  has a pending follow request.
 * `postFollow()` - Allows the authenticating users to follow the user specified in the ID parameter.
 * `postUnfollow()` - Allows the authenticating user to unfollow the user specified in the ID parameter.
 * `postFollowUpdate()` - Allows one to enable or disable retweets and device notifications from the specified user.
 * `getFriendships()` - Returns detailed information about the relationship between two arbitrary users.
-* `getFriends()` - Returns a cursored collection of user objects for every user the specified user is following (otherwise known as their “friends”).
+* `getFriends()` - Returns a cursored collection of user objects for every user the specified user is following (
+  otherwise known as their “friends”).
 * `getFollowers()` - Returns a cursored collection of user objects for users following the specified user.
-* `getFriendshipsLookup()` - Returns the relationships of the authenticating user to the comma-separated list of up to 100 screen_names or user_ids provided. Values for connections can be: following, following_requested, followed_by, none, blocking, muting.
+* `getFriendshipsLookup()` - Returns the relationships of the authenticating user to the comma-separated list of up to
+  100 screen_names or user_ids provided. Values for connections can be: following, following_requested, followed_by,
+  none, blocking, muting.
 
 #### Geo
 
 * `getGeo()` - Returns all the information about a known place.
-* `getGeoReverse()` - Given a latitude and a longitude, searches for up to 20 places that can be used as a place_id when updating a status.
-* `getGeoSearch()` - Search for places that can be attached to a statuses/update. Given a latitude and a longitude pair, an IP address, or a name, this request will return a list of all the valid places that can be used as the place_id when updating a status.
-* `getGeoSimilar()` - Locates places near the given coordinates which are similar in name. Conceptually you would use this method to get a list of known places to choose from first. Then, if the desired place doesn't exist, make a request to POST geo/place to create a new one. The token contained in the response is the token needed to be able to create a new place.
+* `getGeoReverse()` - Given a latitude and a longitude, searches for up to 20 places that can be used as a place_id when
+  updating a status.
+* `getGeoSearch()` - Search for places that can be attached to a statuses/update. Given a latitude and a longitude pair,
+  an IP address, or a name, this request will return a list of all the valid places that can be used as the place_id
+  when updating a status.
+* `getGeoSimilar()` - Locates places near the given coordinates which are similar in name. Conceptually you would use
+  this method to get a list of known places to choose from first. Then, if the desired place doesn't exist, make a
+  request to POST geo/place to create a new one. The token contained in the response is the token needed to be able to
+  create a new place.
 
 #### Help
 
-* `postSpam()` - Report the specified user as a spam account to Twitter. Additionally performs the equivalent of POST blocks / create on behalf of the authenticated user.
-* `getHelpConfiguration()` - Returns the current configuration used by Twitter including twitter.com slugs which are not usernames, maximum photo resolutions, and t.co URL lengths.
-* `getHelpLanguages()` - Returns the list of languages supported by Twitter along with the language code supported by Twitter.
+* `postSpam()` - Report the specified user as a spam account to Twitter. Additionally performs the equivalent of POST
+  blocks / create on behalf of the authenticated user.
+* `getHelpConfiguration()` - Returns the current configuration used by Twitter including twitter.com slugs which are not
+  usernames, maximum photo resolutions, and t.co URL lengths.
+* `getHelpLanguages()` - Returns the list of languages supported by Twitter along with the language code supported by
+  Twitter.
 * `getHelpPrivacy()` - Returns Twitter’s Privacy Policy.
 * `getHelpTos()` - Returns the Twitter Terms of Service. Note: these are not the same as the Developer Policy.
 * `getAppRateLimit()` - Returns the current rate limits for methods belonging to the specified resource families.
 
 #### List
 
-* `getLists()` - Returns all lists the authenticating or specified user subscribes to, including their own. The user is specified using the user_id or screen_name parameters. If no user is given, the authenticating user is used.
-* `getListStatuses()` - Returns a timeline of tweets authored by members of the specified list. Retweets are included by default. Use the include_rts=false parameter to omit retweets.
-* `destroyListMember()` - Removes the specified member from the list. The authenticated user must be the list’s owner to remove members from the list.
-* `getListsMemberships()` - Returns the lists the specified user has been added to. If user_id or screen_name are not provided the memberships for the authenticating user are returned.
-* `getListsSubscribers()` - Returns the subscribers of the specified list. Private list subscribers will only be shown if the authenticated user owns the specified list.
+* `getLists()` - Returns all lists the authenticating or specified user subscribes to, including their own. The user is
+  specified using the user_id or screen_name parameters. If no user is given, the authenticating user is used.
+* `getListStatuses()` - Returns a timeline of tweets authored by members of the specified list. Retweets are included by
+  default. Use the include_rts=false parameter to omit retweets.
+* `destroyListMember()` - Removes the specified member from the list. The authenticated user must be the list’s owner to
+  remove members from the list.
+* `getListsMemberships()` - Returns the lists the specified user has been added to. If user_id or screen_name are not
+  provided the memberships for the authenticating user are returned.
+* `getListsSubscribers()` - Returns the subscribers of the specified list. Private list subscribers will only be shown
+  if the authenticated user owns the specified list.
 * `postListSubscriber()` - Subscribes the authenticated user to the specified list.
-* `getListSubscriber()` - Returns the subscribers of the specified list. Private list subscribers will only be shown if the authenticated user owns the specified list.
+* `getListSubscriber()` - Returns the subscribers of the specified list. Private list subscribers will only be shown if
+  the authenticated user owns the specified list.
 * `destroyListSubscriber()` - Unsubscribes the authenticated user from the specified list.
-* `postListCreateAll()` - Adds multiple members to a list, by specifying a comma-separated list of member ids or screen names. The authenticated user must own the list to be able to add members to it. Note that lists can’t have more than 5,000 members, and you are limited to adding up to 100 members to a list at a time with this method.
+* `postListCreateAll()` - Adds multiple members to a list, by specifying a comma-separated list of member ids or screen
+  names. The authenticated user must own the list to be able to add members to it. Note that lists can’t have more than
+  5,000 members, and you are limited to adding up to 100 members to a list at a time with this method.
 * `getListMember()` - Check if the specified user is a member of the specified list.
-* `getListMembers()` - Returns the members of the specified list. Private list members will only be shown if the authenticated user owns the specified list.
-* `postListMember()` - Add a member to a list. The authenticated user must own the list to be able to add members to it. Note that lists cannot have more than 5,000 members.
+* `getListMembers()` - Returns the members of the specified list. Private list members will only be shown if the
+  authenticated user owns the specified list.
+* `postListMember()` - Add a member to a list. The authenticated user must own the list to be able to add members to it.
+  Note that lists cannot have more than 5,000 members.
 * `destroyList()` - Deletes the specified list. The authenticated user must own the list to be able to destroy it.
 * `postListUpdate()` - Updates the specified list. The authenticated user must own the list to be able to update it.
-* `postList()` - Creates a new list for the authenticated user. Note that you can’t create more than 20 lists per account.
-* `getList()` - Returns the specified list. Private lists will only be shown if the authenticated user owns the specified list.
-* `getListSubscriptions()` - Obtain a collection of the lists the specified user is subscribed to, 20 lists per page by default. Does not include the user’s own lists.
-* `destroyListMembers()` - Removes multiple members from a list, by specifying a comma-separated list of member ids or screen names. The authenticated user must own the list to be able to remove members from it. Note that lists can’t have more than 500 members, and you are limited to removing up to 100 members to a list at a time with this method.
-* `getListOwnerships()` - Returns the lists owned by the specified Twitter user. Private lists will only be shown if the authenticated user is also the owner of the lists.
+* `postList()` - Creates a new list for the authenticated user. Note that you can’t create more than 20 lists per
+  account.
+* `getList()` - Returns the specified list. Private lists will only be shown if the authenticated user owns the
+  specified list.
+* `getListSubscriptions()` - Obtain a collection of the lists the specified user is subscribed to, 20 lists per page by
+  default. Does not include the user’s own lists.
+* `destroyListMembers()` - Removes multiple members from a list, by specifying a comma-separated list of member ids or
+  screen names. The authenticated user must own the list to be able to remove members from it. Note that lists can’t
+  have more than 500 members, and you are limited to removing up to 100 members to a list at a time with this method.
+* `getListOwnerships()` - Returns the lists owned by the specified Twitter user. Private lists will only be shown if the
+  authenticated user is also the owner of the lists.
 
 #### Media
 
@@ -167,45 +218,67 @@ It is safe to call `Twitter::forApiV1()` on either a `v1` or `v2` client instanc
 
 * `getSearch()` - Returns a collection of relevant Tweets matching a specified query.
 * `getSavedSearches()` - Returns the authenticated user’s saved search queries.
-* `getSavedSearch()` - Retrieve the information for the saved search represented by the given id. The authenticating user must be the owner of saved search ID being requested.
+* `getSavedSearch()` - Retrieve the information for the saved search represented by the given id. The authenticating
+  user must be the owner of saved search ID being requested.
 * `postSavedSearch()` - Create a new saved search for the authenticated user. A user may only have 25 saved searches.
-* `destroySavedSearch()` - Destroys a saved search for the authenticating user. The authenticating user must be the owner of saved search id being destroyed.
+* `destroySavedSearch()` - Destroys a saved search for the authenticating user. The authenticating user must be the
+  owner of saved search id being destroyed.
 
 #### Status
 
-* `getMentionsTimeline()` - Returns the 20 most recent mentions (tweets containing a users’s @screen_name) for the authenticating user.
-* `getUserTimeline()` - Returns a collection of the most recent Tweets posted by the user indicated by the screen_name or user_id parameters.
-* `getHomeTimeline()` - Returns a collection of the most recent Tweets and retweets posted by the authenticating user and the users they follow. The home timeline is central to how most users interact with the Twitter service.
-	 *
-* `getRtsTimeline()` - Returns the most recent tweets authored by the authenticating user that have been retweeted by others.
+* `getMentionsTimeline()` - Returns the 20 most recent mentions (tweets containing a users’s @screen_name) for the
+  authenticating user.
+* `getUserTimeline()` - Returns a collection of the most recent Tweets posted by the user indicated by the screen_name
+  or user_id parameters.
+* `getHomeTimeline()` - Returns a collection of the most recent Tweets and retweets posted by the authenticating user
+  and the users they follow. The home timeline is central to how most users interact with the Twitter service.
+    *
+* `getRtsTimeline()` - Returns the most recent tweets authored by the authenticating user that have been retweeted by
+  others.
 * `getRts()` - Returns a collection of the 100 most recent retweets of the tweet specified by the id parameter.
-* `getTweet()` - Returns a single Tweet, specified by the id parameter. The Tweet’s author will also be embedded within the tweet.
-* `destroyTweet()` - Destroys the status specified by the required ID parameter. The authenticating user must be the author of the specified status. Returns the destroyed status if successful.
+* `getTweet()` - Returns a single Tweet, specified by the id parameter. The Tweet’s author will also be embedded within
+  the tweet.
+* `destroyTweet()` - Destroys the status specified by the required ID parameter. The authenticating user must be the
+  author of the specified status. Returns the destroyed status if successful.
 * `postTweet()` - Updates the authenticating user’s current status, also known as tweeting.
-* `postRt()` -  Retweets a tweet. Returns the original tweet with retweet details embedded.
-* `getOembed()` - Returns a single Tweet, specified by either a Tweet web URL or the Tweet ID, in an oEmbed-compatible format. The returned HTML snippet will be automatically recognized as an Embedded Tweet when Twitter’s widget JavaScript is included on the page.
-* `getRters()` - Returns a collection of up to 100 user IDs belonging to users who have retweeted the tweet specified by the id parameter.
-* `getStatusesLookup()` - Returns fully-hydrated tweet objects for up to 100 tweets per request, as specified by comma-separated values passed to the id parameter.
+* `postRt()` - Retweets a tweet. Returns the original tweet with retweet details embedded.
+* `getOembed()` - Returns a single Tweet, specified by either a Tweet web URL or the Tweet ID, in an oEmbed-compatible
+  format. The returned HTML snippet will be automatically recognized as an Embedded Tweet when Twitter’s widget
+  JavaScript is included on the page.
+* `getRters()` - Returns a collection of up to 100 user IDs belonging to users who have retweeted the tweet specified by
+  the id parameter.
+* `getStatusesLookup()` - Returns fully-hydrated tweet objects for up to 100 tweets per request, as specified by
+  comma-separated values passed to the id parameter.
 
 #### Trend
 
-* `getTrendsPlace()` - Returns the top 10 trending topics for a specific WOEID, if trending information is available for it.
+* `getTrendsPlace()` - Returns the top 10 trending topics for a specific WOEID, if trending information is available for
+  it.
 * `getTrendsAvailable()` - Returns the locations that Twitter has trending topic information for.
-* `getTrendsClosest()` - Returns the locations that Twitter has trending topic information for, closest to a specified location.
+* `getTrendsClosest()` - Returns the locations that Twitter has trending topic information for, closest to a specified
+  location.
 
 #### User
 
-* `getUsersLookup()` - Returns fully-hydrated user objects for up to 100 users per request, as specified by comma-separated values passed to the user_id and/or screen_name parameters.
-* `getUsers()` - Returns a variety of information about the user specified by the required user_id or screen_name parameter. The author’s most recent Tweet will be returned inline when possible.
-* `getUsersSearch()` - Provides a simple, relevance-based search interface to public user accounts on Twitter. Try querying by topical interest, full name, company name, location, or other criteria. Exact match searches are not supported.
-* `getUserBanner()` - Returns a map of the available size variations of the specified user’s profile banner. If the user has not uploaded a profile banner, a HTTP 404 will be served instead. This method can be used instead of string manipulation on the profile_banner_url returned in user objects as described in Profile Images and Banners.
+* `getUsersLookup()` - Returns fully-hydrated user objects for up to 100 users per request, as specified by
+  comma-separated values passed to the user_id and/or screen_name parameters.
+* `getUsers()` - Returns a variety of information about the user specified by the required user_id or screen_name
+  parameter. The author’s most recent Tweet will be returned inline when possible.
+* `getUsersSearch()` - Provides a simple, relevance-based search interface to public user accounts on Twitter. Try
+  querying by topical interest, full name, company name, location, or other criteria. Exact match searches are not
+  supported.
+* `getUserBanner()` - Returns a map of the available size variations of the specified user’s profile banner. If the user
+  has not uploaded a profile banner, a HTTP 404 will be served instead. This method can be used instead of string
+  manipulation on the profile_banner_url returned in user objects as described in Profile Images and Banners.
 * `muteUser()` - Mutes the user specified in the ID parameter for the authenticating user.
 * `unmuteUser()` - Un-mutes the user specified in the ID parameter for the authenticating user.
 * `mutedUserIds()` - Returns an array of numeric user ids the authenticating user has muted.
 * `mutedUsers()` - Returns an array of user objects the authenticating user has muted.
 * `getSuggesteds()` - Access the users in a given category of the Twitter suggested user list.
-* `getSuggestions()` - Access to Twitter’s suggested user list. This returns the list of suggested user categories. The category can be used in GET users / suggestions / :slug to get the users in that category.
-* `getSuggestedsMembers()` - Access the users in a given category of the Twitter suggested user list and return their most recent status if they are not a protected user.
+* `getSuggestions()` - Access to Twitter’s suggested user list. This returns the list of suggested user categories. The
+  category can be used in GET users / suggestions / :slug to get the users in that category.
+* `getSuggestedsMembers()` - Access the users in a given category of the Twitter suggested user list and return their
+  most recent status if they are not a protected user.
 
 ### Twitter API v2
 
@@ -217,18 +290,22 @@ It is safe to call `Twitter::forApiV1()` on either a `v1` or `v2` client instanc
 #### Search Tweets
 
 * `searchRecent()` - The recent search endpoint returns Tweets from the last seven days that match a search query.
-* `searchAll()` - The full-archive search endpoint returns the complete history of public Tweets matching a search query; since the first Tweet was created March 26, 2006.
+* `searchAll()` - The full-archive search endpoint returns the complete history of public Tweets matching a search
+  query; since the first Tweet was created March 26, 2006.
 
-  **Note:** oThis endpoint is only available to those approved for the Academic Research product track.
+  **Note:** This endpoint is only available to those approved for the Academic Research product track.
 
 #### Timelines
 
-* `userTweets()` - Returns Tweets composed by a single user, specified by the requested user ID. By default, the most recent ten Tweets are returned per request. Using pagination, the most recent 3,200 Tweets can be retrieved.
-* `userMentions()` - Returns Tweets mentioning a single user specified by the requested user ID. By default, the most recent ten Tweets are returned per request. Using pagination, up to the most recent 800 Tweets can be retrieved.
+* `userTweets()` - Returns Tweets composed by a single user, specified by the requested user ID. By default, the most
+  recent ten Tweets are returned per request. Using pagination, the most recent 3,200 Tweets can be retrieved.
+* `userMentions()` - Returns Tweets mentioning a single user specified by the requested user ID. By default, the most
+  recent ten Tweets are returned per request. Using pagination, up to the most recent 800 Tweets can be retrieved.
 
 #### Filtered Stream
 
-* `getStreamRules()` - Return a list of rules currently active on the streaming endpoint, either as a list or individually.
+* `getStreamRules()` - Return a list of rules currently active on the streaming endpoint, either as a list or
+  individually.
 * `postStreamRules()` - Add or delete rules to your stream.
 * `getStream()` - Streams Tweets in real-time based on a specific set of filter rules.
 
@@ -240,34 +317,44 @@ It is safe to call `Twitter::forApiV1()` on either a `v1` or `v2` client instanc
 
 * `hideTweet()` - Hides or unhides a reply to a Tweet.
 
+#### Tweet Counts
+
+* `countRecent()` - Receive a count of Tweets that match a query in the last 7 days
+* `countAll()` - Receive a count of Tweets that match a query
+
+  **Note:** Only available via the Academic Research product track.
+
 ## Helper Functions
 
-Linkify : Transforms URLs, @usernames, hashtags into links.
-The type of $tweet can be object, array or text.
-By sending an object or an array the method will expand links (t.co) too.
+Linkify : Transforms URLs, @usernames, hashtags into links. The type of $tweet can be object, array or text. By sending
+an object or an array the method will expand links (t.co) too.
+
 ```php
 Twitter::linkify($tweet);
 ```
 
 Ago : Converts date into difference (2 hours ago)
+
 ```php
 Twitter::ago($timestamp);
 ```
 
 LinkUser : Generates a link to a specific user, by their user object (such as $tweet->user), or id/string.
+
 ```php
 Twitter::linkUser($user);
 ```
 
 LinkTweet : Generates a link to a specific tweet.
+
 ```php
 Twitter::linkTweet($tweet);
 ```
 
-
 ## Examples
 
 Returns a collection of the most recent Tweets posted by the user indicated by the screen_name or user_id parameters.
+
 ```php
 Route::get('/userTimeline', function()
 {
@@ -276,6 +363,7 @@ Route::get('/userTimeline', function()
 ```
 
 Returns a collection of the most recent Tweets and retweets posted by the authenticating user and the users they follow.
+
 ```php
 Route::get('/homeTimeline', function()
 {
@@ -284,6 +372,7 @@ Route::get('/homeTimeline', function()
 ```
 
 Returns the X most recent mentions (tweets containing a users's @screen_name) for the authenticating user.
+
 ```php
 Route::get('/mentionsTimeline', function()
 {
@@ -292,6 +381,7 @@ Route::get('/mentionsTimeline', function()
 ```
 
 Updates the authenticating user's current status, also known as tweeting.
+
 ```php
 Route::get('/tweet', function()
 {
@@ -300,6 +390,7 @@ Route::get('/tweet', function()
 ```
 
 Updates the authenticating user's current status with media.
+
 ```php
 Route::get('/tweetMedia', function()
 {
@@ -309,17 +400,20 @@ Route::get('/tweetMedia', function()
 ```
 
 Get User Credentials with email.
+
 ```php
 $credentials = Twitter::getCredentials([
     'include_email' => 'true',
 ]);
 ```
+
 > In the above, you need to pass true as a string, not as a boolean. The boolean will get converted to `1` which Twitter ignores.
 
 > This also is assuming you have your permissions setup correctly with Twitter. You have to choose 'Get user email' when you set up your Twitter app, passing the value alone will not be enough.
 
 
 Sign in with twitter
+
 ```php
 use Atymic\Twitter\Facade\Twitter;
 
@@ -387,6 +481,7 @@ Route::get('twitter/logout', ['as' => 'twitter.logout', function () {
 ### Twitter API v2 Examples
 
 Get user tweets:
+
 ```php
 // ...
 
@@ -410,6 +505,7 @@ public function userTweets(int $userId): JsonResponse
 ```
 
 Search tweets:
+
 ```php
 // ...
 public function searchRecent(string $query): JsonResponse
@@ -423,6 +519,22 @@ public function searchRecent(string $query): JsonResponse
 
     return JsonResponse::fromJsonString(Twitter::searchRecent($query, $params));
 }
+// ...
+```
+
+###### Call a newly added endpoint:
+
+Since Twitter API v2 is being actively developed, you might need to call an endpoint we did not explicitly document in
+the "Functions" section above. Here is an example of how you may use this package to make calls to any newly added
+endpoints. Here we use the newly added "recent count" endpoint.
+
+```php
+// ...
+$querier = \Atymic\Twitter\Facade\Twitter::forApiV2()
+    ->getQuerier();
+$result = $querier
+    ->withOAuth2Client()
+    ->get('tweets/counts/recent', ['query' => 'foo']);
 // ...
 ```
 

--- a/src/Concern/TweetCounts.php
+++ b/src/Concern/TweetCounts.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atymic\Twitter\Concern;
+
+use Atymic\Twitter\Exception\ClientException;
+
+trait TweetCounts
+{
+    use ApiV2Behavior;
+
+    /**
+     * @throws ClientException
+     * @see https://developer.twitter.com/en/docs/twitter-api/tweets/counts/api-reference/get-tweets-counts-recent
+     */
+    public function countRecent(string $query, array $additionalParameters = [])
+    {
+        $queryParameters = array_merge($additionalParameters, ['query' => $query]);
+
+        return $this->getQuerier()
+            ->withOAuth2Client()
+            ->get('tweets/counts/recent', $this->withDefaultParams($queryParameters));
+    }
+
+    /**
+     * @throws ClientException
+     * @see https://developer.twitter.com/en/docs/twitter-api/tweets/counts/api-reference/get-tweets-counts-all
+     */
+    public function countAll(string $query, array $additionalParameters = [])
+    {
+        $queryParameters = array_merge($additionalParameters, ['query' => $query]);
+
+        return $this->getQuerier()
+            ->withOAuth2Client()
+            ->get('tweets/counts/all', $this->withDefaultParams($queryParameters));
+    }
+}

--- a/src/Contract/Twitter.php
+++ b/src/Contract/Twitter.php
@@ -132,5 +132,17 @@ interface Twitter extends BaseTwitterContract
      */
     public function hideTweet(string $tweetId, bool $hidden = true);
 
+    /**
+     * @throws ClientException
+     * @see https://developer.twitter.com/en/docs/twitter-api/tweets/counts/api-reference/get-tweets-counts-recent
+     */
+    public function countRecent(string $query, array $additionalParameters = []);
+
+    /**
+     * @throws ClientException
+     * @see https://developer.twitter.com/en/docs/twitter-api/tweets/counts/api-reference/get-tweets-counts-all
+     */
+    public function countAll(string $query, array $additionalParameters = []);
+
     public function getQuerier(): QuerierContract;
 }

--- a/src/Service/Accessor.php
+++ b/src/Service/Accessor.php
@@ -11,6 +11,7 @@ use Atymic\Twitter\Concern\HotSwapper;
 use Atymic\Twitter\Concern\SampledStream;
 use Atymic\Twitter\Concern\SearchTweets;
 use Atymic\Twitter\Concern\Timelines;
+use Atymic\Twitter\Concern\TweetCounts;
 use Atymic\Twitter\Concern\TweetLookup;
 use Atymic\Twitter\Concern\UserLookup;
 use Atymic\Twitter\Contract\Querier as QuerierContract;
@@ -27,6 +28,7 @@ final class Accessor implements TwitterContract
     use Follows;
     use HideReplies;
     use HotSwapper;
+    use TweetCounts;
 
     private QuerierContract $querier;
 

--- a/tests/Unit/Concern/TweetCountsTest.php
+++ b/tests/Unit/Concern/TweetCountsTest.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * @noinspection PhpParamsInspection
+ */
+
+declare(strict_types=1);
+
+namespace Atymic\Twitter\Tests\Unit\Concern;
+
+use Atymic\Twitter\Concern\TweetCounts;
+use Exception;
+use Prophecy\Argument;
+
+final class TweetCountsTest extends ConcernTestCase
+{
+    /**
+     * @throws Exception
+     */
+    public function testCountRecent(): void
+    {
+        $query = 'foobar';
+
+        $this->querier->get(
+            'tweets/counts/recent',
+            Argument::that(
+                fn (array $argument) => $argument['query'] === $query
+            )
+        )->shouldBeCalledTimes(1);
+
+        $this->subject->countRecent($query);
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testCountAll(): void
+    {
+        $query = 'foobar';
+
+        $this->querier->get(
+            'tweets/counts/all',
+            Argument::that(
+                fn (array $argument) => $argument['query'] === $query
+            )
+        )->shouldBeCalledTimes(1);
+
+        $this->subject->countAll($query);
+    }
+
+    protected function getTraitName(): string
+    {
+        return TweetCounts::class;
+    }
+}


### PR DESCRIPTION
The changes herein:
 
1. expose the new tweet count [endpoints](https://developer.twitter.com/en/docs/twitter-api/tweets/counts/api-reference)
2. add notes and example on how to use newly added v2 endpoint

ref: #365 