### PR TITLE
fix: re-add account activity trait

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ It is safe to call `Twitter::forApiV1()` on either a `v1` or `v2` client instanc
 * `postUserBanner()` - Uploads a profile banner on behalf of the authenticating user. For best results, upload an
   profile_banner_url node in their Users objects.
 
-### Account Activity (Premium)
+#### Account Activity (Premium)
 
 * `setWebhook($env, $url)` - Registers a webhook url for all event types in the given environment.
 * `crcHash($crcToken)` - Returns HMAC SHA-256 hash from the given CRC token and consumer secret. You'll need to return this on your webhook ([more info](https://developer.twitter.com/en/docs/accounts-and-users/subscribe-account-activity/guides/securing-webhooks)).
@@ -109,7 +109,7 @@ It is safe to call `Twitter::forApiV1()` on either a `v1` or `v2` client instanc
 * `getSubscriptionsList($env)` - Returns a list of the current All Activity type subscriptions.
 * `destroyUserSubscriptions($env, $userId)` - Deactivates subscription for the specified user id from the environment. Returns true on success.
 
-### Block
+#### Block
 
 * `getBlocks()` - Returns a collection of user objects that the authenticating user is blocking.
 * `getBlocksIds()` - Returns an array of numeric user ids the authenticating user is blocking.

--- a/README.md
+++ b/README.md
@@ -96,7 +96,20 @@ It is safe to call `Twitter::forApiV1()` on either a `v1` or `v2` client instanc
 * `postUserBanner()` - Uploads a profile banner on behalf of the authenticating user. For best results, upload an
   profile_banner_url node in their Users objects.
 
-#### Block
+### Account Activity (Premium)
+
+* `setWebhook($env, $url)` - Registers a webhook url for all event types in the given environment.
+* `crcHash($crcToken)` - Returns HMAC SHA-256 hash from the given CRC token and consumer secret. You'll need to return this on your webhook ([more info](https://developer.twitter.com/en/docs/accounts-and-users/subscribe-account-activity/guides/securing-webhooks)).
+* `getWebhooks($env)` - Returns webhook URLs for the given environment (or all environments if none provided), and their statuses for the authenticating app.
+* `updateWebhooks($env, $webhookId)` - Triggers the challenge response check (CRC) for the given enviroments webhook for all activites. If the check is successful, returns true and reenables the webhook by setting its status to valid.
+* `destroyWebhook($env, $webhookId)` - Removes the webhook from the provided application's all activities configuration. Returns true on success.
+* `setSubscriptions($env)` - Subscribes the provided application to all events for the provided environment for all message types. Returns true on success.
+* `getSubscriptions($env)` - Returns true if the provided user context has an active subscription with provided application.
+* `getSubscriptionsCount()` - Returns the count of subscriptions that are currently active on your account for all activities.
+* `getSubscriptionsList($env)` - Returns a list of the current All Activity type subscriptions.
+* `destroyUserSubscriptions($env, $userId)` - Deactivates subscription for the specified user id from the environment. Returns true on success.
+
+### Block
 
 * `getBlocks()` - Returns a collection of user objects that the authenticating user is blocking.
 * `getBlocksIds()` - Returns an array of numeric user ids the authenticating user is blocking.
@@ -401,7 +414,7 @@ Route::get('/tweetMedia', function()
 
 Get User Credentials with email.
 
-```php
+```
 $credentials = Twitter::getCredentials([
     'include_email' => 'true',
 ]);
@@ -475,6 +488,17 @@ Route::get('twitter/logout', ['as' => 'twitter.logout', function () {
     Session::forget('access_token');
 
     return Redirect::to('/')->with('notice', 'You\'ve successfully logged out!');
+}]);
+```
+
+Webhook
+>In order to setup webhook successfully, you'll need to return a hash using the CRC token in response from your webhook URL ([more info](https://developer.twitter.com/en/docs/accounts-and-users/subscribe-account-activity/guides/securing-webhooks)).
+```php
+Route::post('twitter/webhook', ['as' => 'twitter.webhook', function(){
+	if (request()->has('crc_token'))
+		return response()->json(['response_token' => Twitter::crcHash(request()->crc_token)], 200);
+	
+	// Your webhook logic goes here
 }]);
 ```
 

--- a/src/ApiV1/Service/Twitter.php
+++ b/src/ApiV1/Service/Twitter.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Atymic\Twitter\ApiV1\Service;
 
 use Atymic\Twitter\ApiV1\Contract\Twitter as TwitterContract;
+use Atymic\Twitter\ApiV1\Traits\AccountActivityTrait;
 use Atymic\Twitter\ApiV1\Traits\AccountTrait;
 use Atymic\Twitter\ApiV1\Traits\AuthTrait;
 use Atymic\Twitter\ApiV1\Traits\BlockTrait;
@@ -29,6 +30,7 @@ class Twitter implements TwitterContract
 {
     use FormattingHelpers;
     use AccountTrait;
+    use AccountActivityTrait;
     use BlockTrait;
     use DirectMessageTrait;
     use FavoriteTrait;

--- a/src/ApiV1/Traits/AccountActivityTrait.php
+++ b/src/ApiV1/Traits/AccountActivityTrait.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Atymic\Twitter\ApiV1\Traits;
+
+trait AccountActivityTrait
+{
+    /**
+     * Creates HMAC SHA-256 hash from incomming crc_token and consumer secret.
+     * This base64 encoded hash needs to be returned by the application when Twitter calls the webhook.
+     *
+     * @param mixed $crcToken
+     *
+     * @return string
+     */
+    public function crcHash($crcToken)
+    {
+        $hash = hash_hmac('sha256', $crcToken, $this->tconfig['CONSUMER_SECRET'], true);
+
+        return 'sha256='.base64_encode($hash);
+    }
+
+    /**
+     * Registers a webhook $url for all event types in the given environment.
+     *
+     * @param mixed $env
+     * @param mixed $url
+     *
+     * @return object
+     */
+    public function setWebhook($env, $url)
+    {
+        return $this->post("account_activity/all/{$env}/webhooks", ['url' => $url]);
+    }
+
+    /**
+     * Returns webhook URLs for the given environment (or all environments if none provided), and their statuses for the authenticating app.
+     *
+     * @param mixed $env
+     *
+     * @return object
+     */
+    public function getWebhooks($env = null)
+    {
+        return $this->get('account_activity/all/'.($env ? $env.'/' : '').'webhooks');
+    }
+
+    /**
+     * Triggers the challenge response check (CRC) for the given enviroments webhook for all activites.
+     * If the check is successful, returns 204 and reenables the webhook by setting its status to valid.
+     *
+     * @param mixed $env
+     * @param mixed $webhookId
+     *
+     * @return bool
+     */
+    public function updateWebhooks($env, $webhookId)
+    {
+        $this->query("account_activity/all/{$env}/webhooks/{$webhookId}", 'PUT');
+
+        return $this->response['code'] === 204;
+    }
+
+    /**
+     * Removes the webhook from the provided application's all activities configuration.
+     * The webhook ID can be accessed by making a call to GET /1.1/account_activity/all/webhooks (getWebhooks).
+     *
+     * @param mixed $env
+     * @param mixed $webhookId
+     *
+     * @return bool
+     */
+    public function destroyWebhook($env, $webhookId)
+    {
+        $this->delete("account_activity/all/{$env}/webhooks/{$webhookId}");
+
+        return $this->response['code'] === 204;
+    }
+
+    /**
+     * Subscribes the provided application to all events for the provided environment for all message types.
+     * Returns HTTP 204 on success.
+     * After activation, all events for the requesting user will be sent to the application’s webhook via POST request.
+     *
+     * @param mixed $env
+     *
+     * @return bool
+     */
+    public function setSubscriptions($env)
+    {
+        $this->post("account_activity/all/{$env}/subscriptions");
+
+        return $this->response['code'] === 204;
+    }
+
+    /**
+     * Provides a way to determine if a webhook configuration is subscribed to the provided user’s events.
+     * If the provided user context has an active subscription with provided application, returns 204 OK.
+     * If the response code is not 204, then the user does not have an active subscription.
+     * See HTTP Response code and error messages for details:
+     * https://developer.twitter.com/en/docs/accounts-and-users/subscribe-account-activity/api-reference/aaa-premium#get-account-activity-all-env-name-subscriptions.
+     *
+     * @param mixed $env
+     *
+     * @return bool
+     */
+    public function getSubscriptions($env)
+    {
+        $this->get("account_activity/all/{$env}/subscriptions");
+
+        return $this->response['code'] === 204;
+    }
+
+    /**
+     * Returns the count of subscriptions that are currently active on your account for all activities.
+     *
+     * @return object
+     */
+    public function getSubscriptionsCount()
+    {
+        return $this->get('account_activity/all/subscriptions/count', [], false, 'json', true);
+    }
+
+    /**
+     * Returns a list of the current All Activity type subscriptions.
+     *
+     * @param mixed $env
+     *
+     * @return object
+     */
+    public function getSubscriptionsList($env)
+    {
+        return $this->get("account_activity/all/{$env}/subscriptions/list", [], false, 'json', true);
+    }
+
+    /**
+     * Deactivates subscription for the specified user id from the environment.
+     * After deactivation, all events for the requesting user will no longer be sent to the webhook URL.
+     *
+     * @param mixed $env
+     * @param mixed $userId
+     *
+     * @return bool
+     */
+    public function destroyUserSubscriptions($env, $userId)
+    {
+        $this->delete("account_activity/all/{$env}/subscriptions/{$userId}", [], false, 'json', true);
+
+        return $this->response['code'] === 204;
+    }
+}

--- a/src/Contract/Http/SyncClient.php
+++ b/src/Contract/Http/SyncClient.php
@@ -18,5 +18,5 @@ interface SyncClient extends Client
     /**
      * @return ResponseInterface|null
      */
-    public function getLastResponse();
+    public function getLastResponse(): ?ResponseInterface;
 }


### PR DESCRIPTION
This re-introduces the missing AccountActivityTrait for API v1.

---
issue: #368  
prev. ref: https://github.com/atymic/twitter/pull/286