### PR TITLE
fix: bump guzzle oauth version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,14 +23,13 @@
         "guzzlehttp/guzzle": "^6.4 || ^7.0",
         "psr/log": "^1.1",
         "nesbot/carbon": "^1.2 || ^2.26",
-        "guzzlehttp/oauth-subscriber": "^0.4",
+        "guzzlehttp/oauth-subscriber": "^0.6",
         "php-di/php-di": "^6.2",
         "kamermans/guzzle-oauth2-subscriber": "^1.0",
         "phpoption/phpoption": "^1.7",
         "vlucas/phpdotenv": "*",
         "react/http": "^1.2",
-        "league/oauth2-client": "^2.6",
-        "guzzlehttp/psr7": "^1.5"
+        "league/oauth2-client": "^2.6"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.3 || ^9.1",


### PR DESCRIPTION
Now that the upstream library fixed PSR7 compat.

Closes #371 