### PR TITLE
Exclude Laravel 9 on PHP 7

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -16,6 +16,8 @@ jobs:
             php-version: 8.0
           - laravel-version: ^7.0
             php-version: 8.0
+          - laravel-version: ^9.0
+            php-version: 7.4
     name: PHP ${{ matrix.php-version }} on Laravel ${{ matrix.laravel-version }}
     steps:
       - name: Checkout


### PR DESCRIPTION
This should fix the action I broke in #387.

My apologies.