### PR TITLE
Detect preceding whitespace for users in linkify

### DIFF
--- a/src/ApiV1/Traits/FormattingHelpers.php
+++ b/src/ApiV1/Traits/FormattingHelpers.php
@@ -32,7 +32,7 @@ trait FormattingHelpers
         $patterns = [];
         $patterns['url'] = '(?xi)\b((?:https?://|www\d{0,3}[.]|[a-z0-9.\-]+[.][a-z]{2,4}/)(?:[^\s()<>]+|\(([^\s()<>]+|(\([^\s()<>]+\)))*\))+(?:\(([^\s()<>]+|(\([^\s()<>]+\)))*\)|[^\s`!()\[\]{};:\'".,<>?«»“”‘’]))';
         $patterns['mailto'] = '([_a-z0-9-]+(\.[_a-z0-9-]+)*@[a-z0-9-]+(\.[a-z0-9-]+)*(\.[a-z]{2,3}))';
-        $patterns['user'] = '(?: +|^)@([A-Za-z0-9_]*)?';
+        $patterns['user'] = '(?:\s+|^)@([A-Za-z0-9_]*)?';
         $patterns['hashtag'] = '(?:(?<=\s)|^)#(\w*[\p{L}\-\d\p{Cyrillic}\d]+\w*)';
         $patterns['long_url'] = '>(([[:alnum:]]+:\/\/)|www\.)?([^[:space:]]{12,22})([^[:space:]]*)([^[:space:]]{12,22})([[:alnum:]#?\/&=])<';
 


### PR DESCRIPTION
changed regex to use `\s` for whitespace