### PR TITLE
Fix: add Content-Type json for API V2 calls

### DIFF
--- a/src/Http/Client/SyncClient.php
+++ b/src/Http/Client/SyncClient.php
@@ -70,7 +70,7 @@ final class SyncClient extends Client implements SyncClientContract
             case self::REQUEST_FORMAT_JSON:
                 return json_encode([
                     $options['headers'] = [
-                        'Content-Type' => 'application/json'
+                        'Content-Type' => 'application/json',
                     ],
                     $options[RequestOptions::JSON] = $params,
                 ]);

--- a/src/Http/Client/SyncClient.php
+++ b/src/Http/Client/SyncClient.php
@@ -68,8 +68,12 @@ final class SyncClient extends Client implements SyncClientContract
     {
         switch ($requestFormat) {
             case self::REQUEST_FORMAT_JSON:
-                $paramsKey = RequestOptions::JSON;
-
+                return json_encode([
+                    $options['headers'] = [
+                        'Content-Type' => 'application/json'
+                    ],
+                    $options[RequestOptions::JSON] = $params,
+                ]);
                 break;
             case self::REQUEST_FORMAT_MULTIPART:
                 $paramsKey = RequestOptions::MULTIPART;


### PR DESCRIPTION
Unless I haven't understood some subtlety of this package, using version 2 of the Twitter API is problematic.

With the code below, I was getting a 400 error from Twitter, indicating that the body should have a Content-Type of type application/json.

```php
Twitter::forApiV2()->getQuerier()->withOAuth1Client()->getSyncClient()->request('POST', 'https://api.twitter.com/2/tweets', [
    'text' => 'tweet text',
    'request_format' => 'json'
]);
```